### PR TITLE
Added support for customizable style properties

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,49 +1,53 @@
 {
-  "pageMargins": {
-    "top": {
-      "target": 13.14,
-      "actual": 13.14
-    },
-    "bottom": {
-      "target": 13.7,
-      "actual": 13.7
-    },
-    "left": {
-      "target": 8.4,
-      "actual": 8.4
-    },
-    "right": {
-      "target": 8.5,
-      "actual": 8.5
-    }
-  },
-  "labelDimensions": {
-    "width": {
-      "target": 25.35,
-      "actual": 25.35
-    },
-    "height": {
-      "target": 10.0,
-      "actual": 10.0
-    }
-  },
-  "labelCount": {
-    "labelsPerRow": 7,
-    "numberOfRows": 27
-  },
-  "spacing": {
-    "horizontal": 2.5,
-    "vertical": 0
-  },
-  "qrCode": {
-    "width": 9,
-    "height": 9,
-    "marginLeft": 0.6
-  },
-  "text": {
-    "fontSize": 11,
-    "fontFamily": "Arial",
-    "maxWidth": 14,
-    "paddingLeft": 1
-  }
-} 
+            "pageMargins": {
+              "top": {
+                "target": 13.14,
+                "actual": 13.14
+              },
+              "bottom": {
+                "target": 13.7,
+                "actual": 13.7
+              },
+              "left": {
+                "target": 8.4,
+                "actual": 8.4
+              },
+              "right": {
+                "target": 8.5,
+                "actual": 8.5
+              }
+            },
+            "labelDimensions": {
+              "width": {
+                "target": 25.35,
+                "actual": 25.35
+              },
+              "height": {
+                "target": 10.0,
+                "actual": 10.0
+              }
+            },
+            "labelCount": {
+              "labelsPerRow": 7,
+              "numberOfRows": 27
+            },
+            "spacing": {
+              "horizontal": 2.5,
+              "vertical": 0
+            },
+            "qrCode": {
+              "width": 9,
+              "height": 9,
+              "marginLeft": 0.5
+            },
+            "text": {
+              "fontSize": 11,
+              "fontFamily": "Arial",
+              "maxWidth": 14,
+              "paddingLeft": 1,
+			  "fontColor": "#000000",
+              "borderColor": "#000000",
+              "borderStyle": "solid",
+              "borderWidth": "0px"
+            }
+          }

--- a/index.html
+++ b/index.html
@@ -2287,7 +2287,7 @@
             text: {
               fontSize: parseInt(alpineApp.textSize),
               fontFamily: alpineApp.textFont,
-              fontWeight: alpineApp.textWeight || 'normal'
+              fontWeight: alpineApp.textWeight || 'normal',
               borderColor: alpineApp.borderColor,
               borderStyle: alpineApp.borderStyle,
               borderWith: alpineApp.borderWith

--- a/index.html
+++ b/index.html
@@ -197,8 +197,9 @@
 		padding: 1mm 0;
         max-width: 14mm;
         line-height: 1;
-		border-top:    var(--border-width, 0mm) var(--border-style, solid) var(--border-color, white);
-        border-bottom: var(--border-width, 0mm) var(--border-style, solid) var(--border-color, white);
+		color: var(--border-color, black);
+		border-top:    var(--border-width, 0mm) var(--border-style, solid) var(--border-color, black);
+        border-bottom: var(--border-width, 0mm) var(--border-style, solid) var(--border-color, black);
       }
       
       /* Neue Styles für A4-Visualisierung */
@@ -1282,6 +1283,26 @@
                       <div class="text-sm text-gray-600">Select the font weight for label text</div>
                     </div>
                   </div>
+				  
+				  <!-- Font Color -->
+                  <div class="input-row">
+                    <div class="input-group">
+                      <label class="text-sm font-medium text-gray-700 flex items-center">
+                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                        Font Color
+                      </label>
+                    </div>
+                    <div class="input-group">
+                      <input type="text" id="fontColor" x-model="fontColor" required 
+                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 prefix-input" 
+                        placeholder="black" />
+                    </div>
+                    <div class="input-group">
+                      <div class="text-sm text-gray-600">Select the font color for label text</div>
+                    </div>
+                  </div>
 
                   <!-- QR Code Spacing -->
                   <div class="input-row">
@@ -1782,7 +1803,8 @@
           selectedLabels: "",
           tonerSaveMode: "off",
           printTestingEnabled: false,
-          borderColor: "#000000",
+          fontColor: "#000000",
+		  borderColor: "#000000",
           borderStyle: "solid",
           borderWidth: "0mm",
 
@@ -1944,7 +1966,8 @@
             root.style.setProperty('--qr-code-spacing', `${this.qrCodeSpacing}mm`);
             root.style.setProperty('--labels-per-row', this.labelsPerRow);
             root.style.setProperty('--max-rows', this.maxRows);
-            root.style.setProperty('--border-color', this.borderColor );
+            root.style.setProperty('--font-color', this.fontColor );
+			root.style.setProperty('--border-color', this.borderColor );
             root.style.setProperty('--border-style', this.borderStyle );
             root.style.setProperty('--border-width', `${this.borderWidth}mm` );
             
@@ -2193,6 +2216,7 @@
               "fontFamily": "Arial",
               "maxWidth": 14,
               "paddingLeft": 1,
+			  "fontColor": "#000000",
               "borderColor": "#000000",
               "borderStyle": "solid",
               "borderWidth": "0px"
@@ -2289,7 +2313,8 @@
               fontSize: parseInt(alpineApp.textSize),
               fontFamily: alpineApp.textFont,
               fontWeight: alpineApp.textWeight || 'normal',
-              borderColor: alpineApp.borderColor || 'black',
+              fontColor: alpineApp.fontColor || 'black',
+			  borderColor: alpineApp.borderColor || 'black',
               borderStyle: alpineApp.borderStyle || 'solid',
               borderWidth: parseFloat(alpineApp.borderWidth)
             },
@@ -2492,7 +2517,8 @@
               alpineApp.textSize = config.text.fontSize;
               alpineApp.textFont = config.text.fontFamily;
               alpineApp.textWeight = config.text.fontWeight;
-              alpineApp.borderColor = config.text.borderColor;
+              alpineApp.fontColor = config.text.fontColor;
+			  alpineApp.borderColor = config.text.borderColor;
               alpineApp.borderStyle = config.text.borderStyle;
               alpineApp.borderWidth = config.text.borderWidth;
             }

--- a/index.html
+++ b/index.html
@@ -1301,6 +1301,84 @@
                       <div class="text-sm text-gray-600">Space between QR code and text (mm)</div>
                     </div>
                   </div>
+                  
+                  <!-- Border Style -->
+                  <div class="input-row">
+                    <div class="input-group">
+                      <label class="text-sm font-medium text-gray-700 flex items-center">
+                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
+                        </svg>
+                        Border Style
+                      </label>
+                    </div>
+                    <div class="input-group">
+                      <select x-model="borderStyle" 
+                        class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <option value="none">none</option>
+                        <option value="solid">solid</option>
+                        <option value="dashed">dashed</option>
+                        <option value="dotted">dotted</option>
+                        <option value="double">double</option>
+                        <option value="groove">groove</option>
+                        <option value="ridge">ridge</option>
+                        <option value="inset">inset</option>
+                        <option value="outset">outset</option>
+                      </select>
+                    </div>
+                    <div class="input-group">
+                      <div class="text-sm text-gray-600">Select the border style for label text</div>
+                    </div>
+                  </div>
+
+                  <!-- Border Size -->
+                  <div class="input-row">
+                    <div class="input-group">
+                      <label class="text-sm font-medium text-gray-700 flex items-center">
+                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
+                        </svg>
+                        Border Size
+                      </label>
+                    </div>
+                    <div class="input-group">
+                      <select x-model="borderSize" 
+                        class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <option value="0">0px</option>
+                        <option value="1">1px</option>
+                        <option value="2">2px</option>
+                        <option value="3">3px</option>
+                        <option value="4">4px</option>
+                        <option value="5">5px</option>
+                        <option value="6">6px</option>
+                        <option value="7">7px</option>
+                        <option value="8">8px</option>
+                      </select>
+                    </div>
+                    <div class="input-group">
+                      <div class="text-sm text-gray-600">Select the border size for label text</div>
+                    </div>
+                  </div>
+
+                  <!-- Border Color -->
+                  <div class="input-row">
+                    <div class="input-group">
+                      <label class="text-sm font-medium text-gray-700 flex items-center">
+                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                        Border Color
+                      </label>
+                    </div>
+                    <div class="input-group">
+                      <input type="text" id="borderColor" x-model="borderColor" required 
+                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 prefix-input" 
+                        placeholder="black" />
+                    </div>
+                    <div class="input-group">
+                      <div class="text-sm text-gray-600">Select the border color for label text</div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1867,7 +1945,7 @@
             root.style.setProperty('--max-rows', this.maxRows);
             root.style.setProperty('--border-color', this.borderColor );
             root.style.setProperty('--border-style', this.borderStyle );
-            root.style.setProperty('--border-width', this.borderWidth );
+            root.style.setProperty('--border-width', `${this.borderWidth}px` );
             
             // Setze die Grid-Templates für beide Container
             const columnsStyle = `repeat(${this.labelsPerRow}, ${this.actualWidth}mm)`;

--- a/index.html
+++ b/index.html
@@ -1288,8 +1288,8 @@
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75" />
                         </svg>
                         Font Color
                       </label>
@@ -1328,8 +1328,8 @@
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
                         </svg>
                         Border Style
                       </label>
@@ -1357,8 +1357,8 @@
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h14.25M3 9h9.75M3 13.5h5.25m5.25-.75L17.25 9m0 0L21 12.75M17.25 9v12" />
                         </svg>
                         Border Size
                       </label>
@@ -1386,8 +1386,8 @@
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
                         </svg>
                         Border Color
                       </label>

--- a/index.html
+++ b/index.html
@@ -196,8 +196,8 @@
         margin-left: 1mm;
         max-width: 14mm;
         line-height: 1;
-        border-bottom: var(--border-with, 0px) var(--border-style, "solid") var(--border-color, "white");
-        border-top: var(--border-with, 0px) var(--border-style, "solid") var(--border-color, "white");
+        border-top:    var(--border-width, 0px) var(--border-style, solid) var(--border-color, white);
+        border-bottom: var(--border-width, 0px) var(--border-style, solid) var(--border-color, white);
       }
       
       /* Neue Styles für A4-Visualisierung */
@@ -1783,7 +1783,7 @@
           printTestingEnabled: false,
           borderColor: "#000000",
           borderStyle: "solid",
-          borderWith: "0px",
+          borderWidth: "0px",
 
           // Page format definitions
           pageFormats: {
@@ -2194,7 +2194,7 @@
               "paddingLeft": 1,
               "borderColor": "#000000",
               "borderStyle": "solid",
-              "borderWith": "0px"
+              "borderWidth": "0px"
             }
           };
           console.log('Verwende Fallback-Konfiguration:', fallbackConfig);
@@ -2290,7 +2290,7 @@
               fontWeight: alpineApp.textWeight || 'normal',
               borderColor: alpineApp.borderColor,
               borderStyle: alpineApp.borderStyle,
-              borderWith: alpineApp.borderWith
+              borderWidth: alpineApp.borderWidth
             },
             display: {
               showBorder: alpineApp.showBorder,
@@ -2493,7 +2493,7 @@
               alpineApp.textWeight = config.text.fontWeight;
               alpineApp.borderColor = config.text.borderColor;
               alpineApp.borderStyle = config.text.borderStyle;
-              alpineApp.borderWith = config.text.borderWith;
+              alpineApp.borderWidth = config.text.borderWidth;
             }
 
             if (config.display) {

--- a/index.html
+++ b/index.html
@@ -193,9 +193,11 @@
         overflow: hidden;
         text-overflow: ellipsis;
         text-align: left;
-        padding-left: 1mm;
+        margin-left: 1mm;
         max-width: 14mm;
         line-height: 1;
+        border-bottom: var(--border-with, 0px) var(--border-style, "solid") var(--border-color, "white");
+        border-top: var(--border-with, 0px) var(--border-style, "solid") var(--border-color, "white");
       }
       
       /* Neue Styles für A4-Visualisierung */
@@ -1701,6 +1703,9 @@
           selectedLabels: "",
           tonerSaveMode: "off",
           printTestingEnabled: false,
+          borderColor: "#000000",
+          borderStyle: "solid",
+          borderWith: "0px",
 
           // Page format definitions
           pageFormats: {
@@ -1860,6 +1865,9 @@
             root.style.setProperty('--qr-code-spacing', `${this.qrCodeSpacing}mm`);
             root.style.setProperty('--labels-per-row', this.labelsPerRow);
             root.style.setProperty('--max-rows', this.maxRows);
+            root.style.setProperty('--border-color', this.borderColor );
+            root.style.setProperty('--border-style', this.borderStyle );
+            root.style.setProperty('--border-width', this.borderWidth );
             
             // Setze die Grid-Templates für beide Container
             const columnsStyle = `repeat(${this.labelsPerRow}, ${this.actualWidth}mm)`;
@@ -2105,7 +2113,10 @@
               "fontSize": 11,
               "fontFamily": "Arial",
               "maxWidth": 14,
-              "paddingLeft": 1
+              "paddingLeft": 1,
+              "borderColor": "#000000",
+              "borderStyle": "solid",
+              "borderWith": "0px"
             }
           };
           console.log('Verwende Fallback-Konfiguration:', fallbackConfig);
@@ -2199,6 +2210,9 @@
               fontSize: parseInt(alpineApp.textSize),
               fontFamily: alpineApp.textFont,
               fontWeight: alpineApp.textWeight || 'normal'
+              borderColor: alpineApp.borderColor,
+              borderStyle: alpineApp.borderStyle,
+              borderWith: alpineApp.borderWith
             },
             display: {
               showBorder: alpineApp.showBorder,
@@ -2399,6 +2413,9 @@
               alpineApp.textSize = config.text.fontSize;
               alpineApp.textFont = config.text.fontFamily;
               alpineApp.textWeight = config.text.fontWeight;
+              alpineApp.borderColor = config.text.borderColor;
+              alpineApp.borderStyle = config.text.borderStyle;
+              alpineApp.borderWith = config.text.borderWith;
             }
 
             if (config.display) {

--- a/index.html
+++ b/index.html
@@ -194,10 +194,11 @@
         text-overflow: ellipsis;
         text-align: left;
         margin-left: 1mm;
+		padding: 1mm 0;
         max-width: 14mm;
         line-height: 1;
-        border-top:    var(--border-width, 0px) var(--border-style, solid) var(--border-color, white);
-        border-bottom: var(--border-width, 0px) var(--border-style, solid) var(--border-color, white);
+		border-top:    var(--border-width, 0mm) var(--border-style, solid) var(--border-color, white);
+        border-bottom: var(--border-width, 0mm) var(--border-style, solid) var(--border-color, white);
       }
       
       /* Neue Styles für A4-Visualisierung */
@@ -1342,17 +1343,17 @@
                       </label>
                     </div>
                     <div class="input-group">
-                      <select x-model="borderSize" 
+                      <select x-model="borderWidth" 
                         class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="0">0px</option>
-                        <option value="1">1px</option>
-                        <option value="2">2px</option>
-                        <option value="3">3px</option>
-                        <option value="4">4px</option>
-                        <option value="5">5px</option>
-                        <option value="6">6px</option>
-                        <option value="7">7px</option>
-                        <option value="8">8px</option>
+                        <option value="0">0mm</option>
+                        <option value="0.5">0.5mm</option>
+                        <option value="1">1mm</option>
+                        <option value="1.5">1.5mm</option>
+                        <option value="2">2mm</option>
+                        <option value="2.5">2.5mm</option>
+                        <option value="3">3mm</option>
+                        <option value="3.5">3.5mm</option>
+                        <option value="4">4mm</option>
                       </select>
                     </div>
                     <div class="input-group">
@@ -1783,7 +1784,7 @@
           printTestingEnabled: false,
           borderColor: "#000000",
           borderStyle: "solid",
-          borderWidth: "0px",
+          borderWidth: "0mm",
 
           // Page format definitions
           pageFormats: {
@@ -1945,7 +1946,7 @@
             root.style.setProperty('--max-rows', this.maxRows);
             root.style.setProperty('--border-color', this.borderColor );
             root.style.setProperty('--border-style', this.borderStyle );
-            root.style.setProperty('--border-width', `${this.borderWidth}px` );
+            root.style.setProperty('--border-width', `${this.borderWidth}mm` );
             
             // Setze die Grid-Templates für beide Container
             const columnsStyle = `repeat(${this.labelsPerRow}, ${this.actualWidth}mm)`;
@@ -2288,9 +2289,9 @@
               fontSize: parseInt(alpineApp.textSize),
               fontFamily: alpineApp.textFont,
               fontWeight: alpineApp.textWeight || 'normal',
-              borderColor: alpineApp.borderColor,
-              borderStyle: alpineApp.borderStyle,
-              borderWidth: alpineApp.borderWidth
+              borderColor: alpineApp.borderColor || 'black',
+              borderStyle: alpineApp.borderStyle || 'solid',
+              borderWidth: parseFloat(alpineApp.borderWidth)
             },
             display: {
               showBorder: alpineApp.showBorder,

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
 		padding: 1mm 0;
         max-width: 14mm;
         line-height: 1;
-		color: var(--border-color, black);
+		color: var(--font-color, black);
 		border-top:    var(--border-width, 0mm) var(--border-style, solid) var(--border-color, black);
         border-bottom: var(--border-width, 0mm) var(--border-style, solid) var(--border-color, black);
       }


### PR DESCRIPTION
Added support for customizable style properties:

-     fontColor: Sets the text color (default: #000000).
-     borderColor: Defines the border color around the element (default: #000000).
-     borderStyle: Controls the style of the border (e.g., solid, dashed, etc.). Default is solid.
-     borderWidth: Sets the thickness of the border. Default is 0mm.