### PR TITLE
Fixed Show Prefix Option

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1938 +1,2009 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>QR Code Label Generator for ASN in Paperless-ngx</title>
-    <link rel="canonical" href="https://tobiasmaier.info/asn-qr-code-label-generator/" />
-    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
-    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-    <style>
-      /* Neue Styles für die Spaltenüberschriften */
-      .column-header {
-        text-align: left;
-        font-weight: bold;
-        padding: 0 0 0.5rem 0;
-        margin: 0 0 0.5rem 0;
-        border-bottom: 1px solid #e5e7eb;
-        font-size: 0.875rem;  /* text-sm */
-      }
 
-      .input-grid {
-        display: grid;
-        grid-template-columns: 2fr 1fr 1fr;  /* Parameter-Spalte breiter als Soll/Ist */
-        gap: 0.75rem;
-        align-items: center;
-      }
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QR Code Label Generator for ASN in Paperless-ngx</title>
+  <link rel="canonical" href="https://tobiasmaier.info/asn-qr-code-label-generator/" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <style>
+    /* Neue Styles für die Spaltenüberschriften */
+    .column-header {
+      text-align: left;
+      font-weight: bold;
+      padding: 0 0 0.5rem 0;
+      margin: 0 0 0.5rem 0;
+      border-bottom: 1px solid #e5e7eb;
+      font-size: 0.875rem;
+      /* text-sm */
+    }
 
-      .input-grid .column-headers {
-        display: contents;
-      }
+    .input-grid {
+      display: grid;
+      grid-template-columns: 2fr 1fr 1fr;
+      /* Parameter-Spalte breiter als Soll/Ist */
+      gap: 0.75rem;
+      align-items: center;
+    }
 
-      .input-grid .input-row {
-        display: contents;
-      }
+    .input-grid .column-headers {
+      display: contents;
+    }
 
-      @media print {
-        @page {
-          size: 210mm 297mm;
-          margin: 0;
-          padding: 0;
-        }
-        
-        html, body {
-          margin: 0 !important;
-          padding: 0 !important;
-          width: 210mm;
-          height: 297mm;
-          position: relative;
-        }
+    .input-grid .input-row {
+      display: contents;
+    }
 
-        .print-hidden {
-          display: none !important;
-        }
-
-        .print-only {
-          display: block !important;
-          position: absolute !important;
-          top: 0 !important;
-          left: 0 !important;
-          margin: 0 !important;
-          padding: 0 !important;
-        width: 210mm;
-        height: 297mm;
-        }
-
-        /* Neue Styles für die Visualisierungen im Druckmodus */
-        .print-only .page-preview {
-          position: absolute !important;
-          top: 0 !important;
-          left: 0 !important;
-          width: 210mm !important;
-          height: 297mm !important;
-          margin: 0 !important;
-          padding: 0 !important;
-        }
-
-        .print-only .padding-visualization,
-        .print-only .label-dimensions-visualization {
-          position: absolute !important;
-          border-color: #000 !important;
-          opacity: 0.5 !important;
-        }
-
-        .print-only .padding-label,
-        .print-only .label-dimensions-label {
-          position: absolute !important;
-          background: none !important;
-        }
-
-        .print-only .text-red-600,
-        .print-only .text-blue-600 {
-          color: #000 !important;
-        }
-
-        .print-only .page {
-          position: absolute !important;
-          top: var(--padding-top) !important;
-          left: var(--padding-left) !important;
-          margin: 0 !important;
-          padding: 0 !important;
-          width: calc(210mm - var(--padding-left) - var(--padding-right)) !important;
-          height: calc(297mm - var(--padding-top) - var(--padding-bottom)) !important;
-          display: grid !important;
-          grid-template-columns: repeat(7, 25.35mm) !important;
-          grid-template-rows: repeat(27, 10.0mm) !important;
-          gap: 0mm 2.5mm !important;
-          box-sizing: border-box !important;
-          transform: none !important;
-          background: none !important;
-        }
-
-        .print-only .label {
-          margin: 0 !important;
-          padding: 0 !important;
-          width: 25.35mm !important;  /* Neue Etikettenbreite */
-          height: 10.0mm !important;  /* Neue Etikettenhöhe */
-          display: flex !important;
-          align-items: center !important;
-          justify-content: flex-start !important;
-          box-sizing: border-box !important;
-          background: none !important;
-        }
-
-        .print-only .qr-code {
-          width: 9mm !important;
-          height: 9mm !important;
-          margin: 0 0 0 var(--qr-code-spacing, 0.6mm) !important;
-          padding: 0 !important;
-        }
-
-        .print-only .text {
-          margin: 0 !important;
-          padding: 0 0 0 1mm !important;
-          font-size: var(--text-size, 11px) !important;
-          line-height: 1 !important;
-          white-space: nowrap !important;
-          overflow: hidden !important;
-          text-overflow: ellipsis !important;
-          max-width: 14mm !important;
-        }
-
-        /* Entferne alle anderen möglichen Einflüsse */
-        .container, .form-container, form {
-          margin: 0 !important;
-          padding: 0 !important;
-        }
-      }
-
-      .page {
-        --mm-to-px: 3.779528;
-        width: calc(210mm - var(--padding-left) - var(--padding-right));
-        height: calc(297mm - var(--padding-top) - var(--padding-bottom));
-        box-sizing: border-box;
-        display: grid;
-        grid-template-columns: repeat(7, 25.61mm);
-        grid-template-rows: repeat(27, 10.06mm);
-        gap: var(--gap-vertical, 0mm) var(--gap-horizontal, 2.63mm);
-        justify-content: start;
-        align-content: start;
-        position: absolute;
-        top: var(--padding-top);
-        left: var(--padding-left);
-        background-color: white;
+    @media print {
+      @page {
+        size: 210mm 297mm;
         margin: 0;
         padding: 0;
       }
-      .label {
-        width: 25.61mm;
-        height: 10.06mm;
-        display: flex;
-        align-items: center;
-        justify-content: flex-start;
-        padding: 0mm;
-        box-sizing: border-box;
-        overflow: hidden;
-        margin: 0;
-        background-color: white;
-      }
-      .qr-code {
-        width: 9mm;
-        height: 9mm;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin-left: var(--qr-code-spacing, 0.6mm);
-      }
-      .text {
-        flex: 1;
-        font-size: var(--text-size, 11px);
-        font-family: var(--text-font, Arial);
-        font-weight: var(--text-weight, normal);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        text-align: left;
-        padding-left: 1mm;
-        max-width: 14mm;
-        line-height: 1;
-      }
-      
-      /* Neue Styles für A4-Visualisierung */
-      .page-preview {
+
+      html,
+      body {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 210mm;
+        height: 297mm;
         position: relative;
-        margin: 20px auto;
-        width: var(--page-width);
-        height: var(--page-height);
-        overflow: visible;
-        background-color: white;
-        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-      }
-      
-      .a4-border {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: var(--page-width);
-        height: var(--page-height);
-        border: 2px solid #000;
-        pointer-events: none;
-        box-sizing: border-box;
-      }
-      
-      .padding-visualization {
-        position: absolute;
-        width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
-        height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
-        border: 2px dashed #ff0000;
-        top: var(--padding-top);
-        left: var(--padding-left);
-        pointer-events: none;
-        box-sizing: border-box;
-      }
-      
-      /* Beschriftungen für Padding */
-      .padding-label {
-        position: absolute;
-        background: rgba(255, 0, 0, 0.1);
-        color: #ff0000;
-        font-size: 12px;
-        display: flex;
-        align-items: center;
-        z-index: 10;
-      }
-      
-      /* Page Margins (rote Werte) */
-      .padding-top {
-        top: 0;
-        left: var(--padding-left);
-        width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
-        height: var(--padding-top);
-        justify-content: flex-start;  /* linksbündig */
-        padding-top: 8mm;  /* Abstand zur gestrichelten Linie */
-      }
-      
-      .padding-bottom {
-        bottom: 0;
-        left: var(--padding-left);
-        width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
-        height: var(--padding-bottom);
-        justify-content: flex-end;    /* rechtsbündig */
-        padding-bottom: 8mm;  /* Abstand zur gestrichelten Linie */
-      }
-      
-      .padding-left {
-        top: var(--padding-top);
-        left: 0;
-        width: var(--padding-left);
-        height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
-        writing-mode: vertical-rl;
-        transform: rotate(180deg);
-        justify-content: flex-end;    /* rechtsbündig */
-        padding-right: 4mm;  /* Abstand zur gestrichelten Linie */
-      }
-      
-      .padding-right {
-        top: var(--padding-top);
-        right: 0;
-        width: var(--padding-right);
-        height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
-        writing-mode: vertical-rl;
-        transform: rotate(180deg);
-        justify-content: flex-start;    /* linksbündig */
-        padding-left: 4mm;  /* Abstand zur gestrichelten Linie */
-      }
-      
-      /* Verstecke blaue Werte im Page Margins Modus */
-      .margin-view-page .padding-label .text-blue-600 {
-        display: none;
-      }
-      
-      /* Verstecke rote Werte im Label Dimensions Modus */
-      .margin-view-label .padding-label .text-red-600 {
-        display: none;
-      }
-      
-      /* Zeige beide Werte im "both" Modus */
-      .margin-view-both .padding-label .text-blue-600,
-      .margin-view-both .padding-label .text-red-600 {
-        display: block;
-      }
-      
-      /* Container für die Vorschau */
-      .preview-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin-top: 2rem;
-        margin-bottom: 2rem;
-        position: relative;
-        width: 100%;
-        overflow-x: auto;
-        padding: 20px;
-      }
-      
-      .main-layout {
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 1rem;
-      }
-      
-      .form-container {
-        width: 100%;
-        max-width: 800px;
-        margin: 0 auto;
       }
 
-      /* Neue Styles für die Eingabefelder */
-      .number-input {
-        width: 100px !important;
-        padding: 0.25rem 0.5rem !important;
-        text-align: right;
-      }
-
-      .prefix-input {
-        width: 100px !important;
-        padding: 0.25rem 0.5rem !important;
-      }
-
-      .text-size-input {
-        width: 100px !important;
-        text-align: right;
-      }
-
-      .font-select {
-        width: 140px !important;
-      }
-
-      .font-weight-select {
-        width: 120px !important;
-      }
-
-      .checkbox-container {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
-
-      .input-group {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-      }
-      
-      .input-group label {
-        font-size: 0.875rem;  /* text-sm */
-      }
-      
-      .input-group input {
-        width: 100%;
-        padding: 0.375rem;
-      }
-      
-      .input-group input[type="number"] {
-        -moz-appearance: textfield;
-      }
-      
-      .input-group input[type="number"]::-webkit-inner-spin-button,
-      .input-group input[type="number"]::-webkit-outer-spin-button {
-        -webkit-appearance: none;
-        margin: 0;
-      }
-      
-      /* Angepasste Styles für Abstände */
-      .section-group {
-        margin-bottom: 1rem; /* Reduziert von 1.5rem (mb-6) auf 1rem (mb-4) */
-      }
-      
-      .section-title {
-        font-size: 1rem;
-        font-weight: 600;
-        margin-bottom: 0.5rem; /* Reduziert von 0.75rem (mb-3) auf 0.5rem (mb-2) */
-      }
-      
-      .input-grid {
-        display: grid;
-        gap: 0.75rem; /* Reduziert von 1.25rem (gap-5) auf 0.75rem (gap-3) */
-      }
-      
-      .input-grid-4 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      
-      @media (min-width: 768px) {
-        .input-grid-4 {
-          grid-template-columns: repeat(4, 1fr);
-        }
-      }
-      
-      .input-grid-2 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      
-      .action-buttons {
-        margin-top: 1rem;
-        display: flex;
-        gap: 0.75rem;
-      }
-      
-      .input-grid-5 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      
-      @media (min-width: 768px) {
-        .input-grid-5 {
-          grid-template-columns: repeat(5, 1fr);
-        }
-      }
-      
-      /* Optimierte Styles für kompakteres Layout */
-      .section-group {
-        margin-bottom: 0.75rem;
-        padding: 0.5rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 0.375rem;
-      }
-      
-      .section-title {
-        font-size: 0.875rem;
-        font-weight: 600;
-        margin-bottom: 0.375rem;
-        color: #374151;
-      }
-      
-      .input-grid {
-        display: grid;
-        gap: 0.5rem;
-      }
-      
-      .input-grid-5 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      
-      @media (min-width: 768px) {
-        .input-grid-5 {
-          grid-template-columns: auto auto auto 1fr 1fr;
-          align-items: center;
-        }
-      }
-      
-      .input-grid-4 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      
-      @media (min-width: 768px) {
-        .input-grid-4 {
-          grid-template-columns: repeat(4, 1fr);
-        }
-      }
-      
-      .input-grid-2 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      
-      .input-group {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-      }
-      
-      .input-group label {
-        font-size: 0.75rem;
-        color: #4b5563;
-      }
-      
-      .number-input {
-        width: 60px !important;
-        padding: 0.25rem 0.5rem !important;
-        text-align: center;
-      }
-      
-      .prefix-input {
-        width: 80px !important;
-        padding: 0.25rem 0.5rem !important;
-      }
-      
-      .checkbox-container {
-        display: flex;
-        align-items: center;
-        gap: 0.375rem;
-        font-size: 0.875rem;
-      }
-      
-      .checkbox-container input[type="checkbox"] {
-        width: 1rem;
-        height: 1rem;
-      }
-      
-      .action-buttons {
-        margin-top: 0.75rem;
-        display: flex;
-        gap: 0.5rem;
-      }
-      
-      .form-container {
-        max-width: 700px;
-        margin: 0 auto;
-        padding: 1rem;
-      }
-      
-      /* Verbesserte Button-Styles */
-      .btn {
-        padding: 0.375rem 0.75rem;
-        border-radius: 0.25rem;
-        font-size: 0.875rem;
-        font-weight: 500;
-        transition: all 0.2s;
-      }
-      
-      .btn-primary {
-        background-color: #2563eb;
-        color: white;
-      }
-      
-      .btn-primary:hover {
-        background-color: #1d4ed8;
-      }
-      
-      .btn-success {
-        background-color: #059669;
-        color: white;
-      }
-      
-      .btn-success:hover {
-        background-color: #047857;
-      }
-
-      @media screen {
-        .print-only {
-          display: none;
-        }
-      }
-
-      .notification {
-        position: fixed;
-        top: 20px;
-        right: 20px;
-        padding: 1rem;
-        border-radius: 0.5rem;
-        color: white;
-        font-weight: bold;
-        z-index: 1000;
-        opacity: 0;
-        transition: opacity 0.3s ease-in-out;
-      }
-
-      .notification.success {
-        background-color: #10B981;
-      }
-
-      .notification.error {
-        background-color: #EF4444;
-      }
-
-      .notification.show {
-        opacity: 1;
-      }
-
-      /* Toggle Switch Styles */
-      .toggle-switch {
-        display: flex;
-        align-items: center;
-      }
-      
-      .switch {
-        position: relative;
-        display: inline-block;
-        width: 48px;
-        height: 24px;
-        margin-left: 12px;
-      }
-      
-      .switch input {
-        opacity: 0;
-        width: 0;
-        height: 0;
-      }
-      
-      .slider {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: #ccc;
-        transition: .4s;
-        border-radius: 24px;
-      }
-      
-      .slider:before {
-        position: absolute;
-        content: "";
-        height: 18px;
-        width: 18px;
-        left: 3px;
-        bottom: 3px;
-        background-color: white;
-        transition: .4s;
-        border-radius: 50%;
-      }
-      
-      input:checked + .slider {
-        background-color: #2563eb;
-      }
-      
-      input:checked + .slider:before {
-        transform: translateX(24px);
-      }
-
-      .print-testing-section {
-        opacity: 0.5;
-        pointer-events: none;
-        transition: all 0.3s ease;
-      }
-
-      .print-testing-section.active {
-        opacity: 1;
-        pointer-events: auto;
-      }
-
-      /* Label Dimensions Visualization */
-      .label-dimensions-visualization {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: none;
-        pointer-events: none;
-        box-sizing: border-box;
-        z-index: 5;
-      }
-      
-      .label-dimensions-visualization::before {
-        content: '';
-        position: absolute;
-        top: var(--padding-top);
-        left: var(--padding-left);
-        width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
-        height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
-        border: 2px dashed #0000ff;
-        box-sizing: border-box;
-        z-index: 5;
-      }
-      
-      .label-dimensions-grid {
-        display: none;  /* Grid ausblenden */
-      }
-      
-      .label-dimensions-cell {
-        display: none;  /* Einzelne Zellen ausblenden */
-      }
-      
-      .hidden {
+      .print-hidden {
         display: none !important;
       }
 
-      /* Label Dimensions Labels (blaue Werte) */
-      .label-dimensions-label {
-        position: absolute;
-        background: rgba(0, 0, 255, 0.1);
-        color: #0000ff;
-        font-size: 12px;
-        display: flex;
+      .print-only {
+        display: block !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 210mm;
+        height: 297mm;
+      }
+
+      /* Neue Styles für die Visualisierungen im Druckmodus */
+      .print-only .page-preview {
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 210mm !important;
+        height: 297mm !important;
+        margin: 0 !important;
+        padding: 0 !important;
+      }
+
+      .print-only .padding-visualization,
+      .print-only .label-dimensions-visualization {
+        position: absolute !important;
+        border-color: #000 !important;
+        opacity: 0.5 !important;
+      }
+
+      .print-only .padding-label,
+      .print-only .label-dimensions-label {
+        position: absolute !important;
+        background: none !important;
+      }
+
+      .print-only .text-red-600,
+      .print-only .text-blue-600 {
+        color: #000 !important;
+      }
+
+      .print-only .page {
+        position: absolute !important;
+        top: var(--padding-top) !important;
+        left: var(--padding-left) !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        width: calc(210mm - var(--padding-left) - var(--padding-right)) !important;
+        height: calc(297mm - var(--padding-top) - var(--padding-bottom)) !important;
+        display: grid !important;
+        grid-template-columns: repeat(7, 25.35mm) !important;
+        grid-template-rows: repeat(27, 10.0mm) !important;
+        gap: 0mm 2.5mm !important;
+        box-sizing: border-box !important;
+        transform: none !important;
+        background: none !important;
+      }
+
+      .print-only .label {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 25.35mm !important;
+        /* Neue Etikettenbreite */
+        height: 10.0mm !important;
+        /* Neue Etikettenhöhe */
+        display: flex !important;
+        align-items: center !important;
+        justify-content: flex-start !important;
+        box-sizing: border-box !important;
+        background: none !important;
+      }
+
+      .print-only .qr-code {
+        width: 9mm !important;
+        height: 9mm !important;
+        margin: 0 0 0 var(--qr-code-spacing, 0.6mm) !important;
+        padding: 0 !important;
+      }
+
+      .print-only .text {
+        margin: 0 !important;
+        padding: 0 0 0 1mm !important;
+        font-size: var(--text-size, 11px) !important;
+        line-height: 1 !important;
+        white-space: nowrap !important;
+        overflow: hidden !important;
+        text-overflow: ellipsis !important;
+        max-width: 14mm !important;
+      }
+
+      /* Entferne alle anderen möglichen Einflüsse */
+      .container,
+      .form-container,
+      form {
+        margin: 0 !important;
+        padding: 0 !important;
+      }
+    }
+
+    .page {
+      --mm-to-px: 3.779528;
+      width: calc(210mm - var(--padding-left) - var(--padding-right));
+      height: calc(297mm - var(--padding-top) - var(--padding-bottom));
+      box-sizing: border-box;
+      display: grid;
+      grid-template-columns: repeat(7, 25.61mm);
+      grid-template-rows: repeat(27, 10.06mm);
+      gap: var(--gap-vertical, 0mm) var(--gap-horizontal, 2.63mm);
+      justify-content: start;
+      align-content: start;
+      position: absolute;
+      top: var(--padding-top);
+      left: var(--padding-left);
+      background-color: white;
+      margin: 0;
+      padding: 0;
+    }
+
+    .label {
+      width: 25.61mm;
+      height: 10.06mm;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      padding: 0mm;
+      box-sizing: border-box;
+      overflow: hidden;
+      margin: 0;
+      background-color: white;
+    }
+
+    .qr-code {
+      width: 9mm;
+      height: 9mm;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: var(--qr-code-spacing, 0.6mm);
+    }
+
+    .text {
+      flex: 1;
+      font-size: var(--text-size, 11px);
+      font-family: var(--text-font, Arial);
+      font-weight: var(--text-weight, normal);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: left;
+      padding-left: 1mm;
+      max-width: 14mm;
+      line-height: 1;
+    }
+
+    /* Neue Styles für A4-Visualisierung */
+    .page-preview {
+      position: relative;
+      margin: 20px auto;
+      width: var(--page-width);
+      height: var(--page-height);
+      overflow: visible;
+      background-color: white;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
+    .a4-border {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: var(--page-width);
+      height: var(--page-height);
+      border: 2px solid #000;
+      pointer-events: none;
+      box-sizing: border-box;
+    }
+
+    .padding-visualization {
+      position: absolute;
+      width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
+      height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
+      border: 2px dashed #ff0000;
+      top: var(--padding-top);
+      left: var(--padding-left);
+      pointer-events: none;
+      box-sizing: border-box;
+    }
+
+    /* Beschriftungen für Padding */
+    .padding-label {
+      position: absolute;
+      background: rgba(255, 0, 0, 0.1);
+      color: #ff0000;
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      z-index: 10;
+    }
+
+    /* Page Margins (rote Werte) */
+    .padding-top {
+      top: 0;
+      left: var(--padding-left);
+      width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
+      height: var(--padding-top);
+      justify-content: flex-start;
+      /* linksbündig */
+      padding-top: 8mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    .padding-bottom {
+      bottom: 0;
+      left: var(--padding-left);
+      width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
+      height: var(--padding-bottom);
+      justify-content: flex-end;
+      /* rechtsbündig */
+      padding-bottom: 8mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    .padding-left {
+      top: var(--padding-top);
+      left: 0;
+      width: var(--padding-left);
+      height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      justify-content: flex-end;
+      /* rechtsbündig */
+      padding-right: 4mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    .padding-right {
+      top: var(--padding-top);
+      right: 0;
+      width: var(--padding-right);
+      height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      justify-content: flex-start;
+      /* linksbündig */
+      padding-left: 4mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    /* Verstecke blaue Werte im Page Margins Modus */
+    .margin-view-page .padding-label .text-blue-600 {
+      display: none;
+    }
+
+    /* Verstecke rote Werte im Label Dimensions Modus */
+    .margin-view-label .padding-label .text-red-600 {
+      display: none;
+    }
+
+    /* Zeige beide Werte im "both" Modus */
+    .margin-view-both .padding-label .text-blue-600,
+    .margin-view-both .padding-label .text-red-600 {
+      display: block;
+    }
+
+    /* Container für die Vorschau */
+    .preview-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+      position: relative;
+      width: 100%;
+      overflow-x: auto;
+      padding: 20px;
+    }
+
+    .main-layout {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+
+    .form-container {
+      width: 100%;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    /* Neue Styles für die Eingabefelder */
+    .number-input {
+      width: 100px !important;
+      padding: 0.25rem 0.5rem !important;
+      text-align: right;
+    }
+
+    .prefix-input {
+      width: 100px !important;
+      padding: 0.25rem 0.5rem !important;
+    }
+
+    .text-size-input {
+      width: 100px !important;
+      text-align: right;
+    }
+
+    .font-select {
+      width: 140px !important;
+    }
+
+    .font-weight-select {
+      width: 120px !important;
+    }
+
+    .checkbox-container {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .input-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .input-group label {
+      font-size: 0.875rem;
+      /* text-sm */
+    }
+
+    .input-group input {
+      width: 100%;
+      padding: 0.375rem;
+    }
+
+    .input-group input[type="number"] {
+      -moz-appearance: textfield;
+    }
+
+    .input-group input[type="number"]::-webkit-inner-spin-button,
+    .input-group input[type="number"]::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    /* Angepasste Styles für Abstände */
+    .section-group {
+      margin-bottom: 1rem;
+      /* Reduziert von 1.5rem (mb-6) auf 1rem (mb-4) */
+    }
+
+    .section-title {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      /* Reduziert von 0.75rem (mb-3) auf 0.5rem (mb-2) */
+    }
+
+    .input-grid {
+      display: grid;
+      gap: 0.75rem;
+      /* Reduziert von 1.25rem (gap-5) auf 0.75rem (gap-3) */
+    }
+
+    .input-grid-4 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (min-width: 768px) {
+      .input-grid-4 {
+        grid-template-columns: repeat(4, 1fr);
+      }
+    }
+
+    .input-grid-2 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .action-buttons {
+      margin-top: 1rem;
+      display: flex;
+      gap: 0.75rem;
+    }
+
+    .input-grid-5 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (min-width: 768px) {
+      .input-grid-5 {
+        grid-template-columns: repeat(5, 1fr);
+      }
+    }
+
+    /* Optimierte Styles für kompakteres Layout */
+    .section-group {
+      margin-bottom: 0.75rem;
+      padding: 0.5rem;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+    }
+
+    .section-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      margin-bottom: 0.375rem;
+      color: #374151;
+    }
+
+    .input-grid {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .input-grid-5 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (min-width: 768px) {
+      .input-grid-5 {
+        grid-template-columns: auto auto auto 1fr 1fr;
         align-items: center;
-        z-index: 10;
       }
-      
-      .label-dimensions-top {
-        top: 0;
-        left: var(--padding-left);
-        width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
-        height: var(--padding-top);
-        justify-content: flex-end;    /* rechtsbündig */
-        padding-top: 8mm;  /* Abstand zur gestrichelten Linie */
+    }
+
+    .input-grid-4 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (min-width: 768px) {
+      .input-grid-4 {
+        grid-template-columns: repeat(4, 1fr);
       }
-      
-      .label-dimensions-bottom {
-        bottom: 0;
-        left: var(--padding-left);
-        width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
-        height: var(--padding-bottom);
-        justify-content: flex-start;  /* linksbündig */
-        padding-bottom: 8mm;  /* Abstand zur gestrichelten Linie */
+    }
+
+    .input-grid-2 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .input-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .input-group label {
+      font-size: 0.75rem;
+      color: #4b5563;
+    }
+
+    .number-input {
+      width: 60px !important;
+      padding: 0.25rem 0.5rem !important;
+      text-align: center;
+    }
+
+    .prefix-input {
+      width: 80px !important;
+      padding: 0.25rem 0.5rem !important;
+    }
+
+    .checkbox-container {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.875rem;
+    }
+
+    .checkbox-container input[type="checkbox"] {
+      width: 1rem;
+      height: 1rem;
+    }
+
+    .action-buttons {
+      margin-top: 0.75rem;
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .form-container {
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+
+    /* Verbesserte Button-Styles */
+    .btn {
+      padding: 0.375rem 0.75rem;
+      border-radius: 0.25rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.2s;
+    }
+
+    .btn-primary {
+      background-color: #2563eb;
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background-color: #1d4ed8;
+    }
+
+    .btn-success {
+      background-color: #059669;
+      color: white;
+    }
+
+    .btn-success:hover {
+      background-color: #047857;
+    }
+
+    @media screen {
+      .print-only {
+        display: none;
       }
-      
-      .label-dimensions-left {
-        top: var(--padding-top);
-        left: 0;
-        width: var(--padding-left);
-        height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
-        writing-mode: vertical-rl;
-        transform: rotate(180deg);
-        justify-content: flex-start;  /* linksbündig */
-        padding-right: 4mm;  /* Abstand zur gestrichelten Linie */
-      }
-      
-      .label-dimensions-right {
-        top: var(--padding-top);
-        right: 0;
-        width: var(--padding-right);
-        height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
-        writing-mode: vertical-rl;
-        transform: rotate(180deg);
-        justify-content: flex-end;    /* rechtsbündig */
-        padding-left: 4mm;  /* Abstand zur gestrichelten Linie */
-      }
-    </style>
-  </head>
-  <body x-data="qrCodeApp()" x-init="generateLabels()">
-    <div class="main-layout">
-      <div class="form-container">
-    <div class="container mx-auto print-hidden">
-          <div class="flex justify-between items-center mb-4">
-            <h1 class="text-xl font-bold">ASN QR Code Label Generator</h1>
-            <span class="text-sm text-gray-600">v0.950</span>
+    }
+
+    .notification {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      color: white;
+      font-weight: bold;
+      z-index: 1000;
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+    }
+
+    .notification.success {
+      background-color: #10B981;
+    }
+
+    .notification.error {
+      background-color: #EF4444;
+    }
+
+    .notification.show {
+      opacity: 1;
+    }
+
+    /* Toggle Switch Styles */
+    .toggle-switch {
+      display: flex;
+      align-items: center;
+    }
+
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 48px;
+      height: 24px;
+      margin-left: 12px;
+    }
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      transition: .4s;
+      border-radius: 24px;
+    }
+
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      transition: .4s;
+      border-radius: 50%;
+    }
+
+    input:checked+.slider {
+      background-color: #2563eb;
+    }
+
+    input:checked+.slider:before {
+      transform: translateX(24px);
+    }
+
+    .print-testing-section {
+      opacity: 0.5;
+      pointer-events: none;
+      transition: all 0.3s ease;
+    }
+
+    .print-testing-section.active {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    /* Label Dimensions Visualization */
+    .label-dimensions-visualization {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border: none;
+      pointer-events: none;
+      box-sizing: border-box;
+      z-index: 5;
+    }
+
+    .label-dimensions-visualization::before {
+      content: '';
+      position: absolute;
+      top: var(--padding-top);
+      left: var(--padding-left);
+      width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
+      height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
+      border: 2px dashed #0000ff;
+      box-sizing: border-box;
+      z-index: 5;
+    }
+
+    .label-dimensions-grid {
+      display: none;
+      /* Grid ausblenden */
+    }
+
+    .label-dimensions-cell {
+      display: none;
+      /* Einzelne Zellen ausblenden */
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    /* Label Dimensions Labels (blaue Werte) */
+    .label-dimensions-label {
+      position: absolute;
+      background: rgba(0, 0, 255, 0.1);
+      color: #0000ff;
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      z-index: 10;
+    }
+
+    .label-dimensions-top {
+      top: 0;
+      left: var(--padding-left);
+      width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
+      height: var(--padding-top);
+      justify-content: flex-end;
+      /* rechtsbündig */
+      padding-top: 8mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    .label-dimensions-bottom {
+      bottom: 0;
+      left: var(--padding-left);
+      width: calc(var(--page-width) - var(--padding-left) - var(--padding-right));
+      height: var(--padding-bottom);
+      justify-content: flex-start;
+      /* linksbündig */
+      padding-bottom: 8mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    .label-dimensions-left {
+      top: var(--padding-top);
+      left: 0;
+      width: var(--padding-left);
+      height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      justify-content: flex-start;
+      /* linksbündig */
+      padding-right: 4mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+
+    .label-dimensions-right {
+      top: var(--padding-top);
+      right: 0;
+      width: var(--padding-right);
+      height: calc(var(--page-height) - var(--padding-top) - var(--padding-bottom));
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      justify-content: flex-end;
+      /* rechtsbündig */
+      padding-left: 4mm;
+      /* Abstand zur gestrichelten Linie */
+    }
+  </style>
+</head>
+
+<body x-data="qrCodeApp()" x-init="generateLabels()">
+  <div class="main-layout">
+    <div class="form-container">
+      <div class="container mx-auto print-hidden">
+        <div class="flex justify-between items-center mb-4">
+          <h1 class="text-xl font-bold">ASN QR Code Label Generator</h1>
+          <span class="text-sm text-gray-600">v0.950</span>
+        </div>
+
+        <div class="flex justify-between gap-4 mb-4 border-b pb-4">
+          <button onclick="saveConfig()"
+            class="flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-center inline-flex items-center justify-center">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+            </svg>
+            Save Configuration
+          </button>
+          <label
+            class="flex-1 bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded cursor-pointer text-center inline-flex items-center justify-center">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+            </svg>
+            Load Configuration
+            <input type="file" id="configUpload" accept=".json" class="hidden" onchange="loadConfig(event)">
+          </label>
+          <button onclick="resetConfig()"
+            class="flex-1 bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded text-center inline-flex items-center justify-center">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Reset to Default
+          </button>
+        </div>
+        <form @submit.prevent="generateLabels()">
+          <!-- QR Code Configuration -->
+          <div class="section-group">
+            <h2 class="section-title">QR Code Settings</h2>
+            <div class="input-grid input-grid-5">
+              <div class="input-group">
+                <label for="prefix" class="text-sm font-medium text-gray-700">ASN Prefix</label>
+                <input type="text" id="prefix" x-model="prefix" required
+                  class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 prefix-input"
+                  placeholder="ASN" />
+              </div>
+              <div class="input-group">
+                <label for="leadingZeros" class="text-sm font-medium text-gray-700">Leading Zeros</label>
+                <input type="number" id="leadingZeros" x-model="leadingZeros" required min="0" max="10" step="1"
+                  class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" />
+              </div>
+              <div class="input-group">
+                <label for="startNumber" class="text-sm font-medium text-gray-700">Start Number</label>
+                <input type="number" id="startNumber" x-model="startNumber" required min="1" step="1"
+                  class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" />
+              </div>
+              <div class="flex-grow"></div>
+              <div class="input-group text-left">
+                <label class="text-sm font-medium text-gray-700">Sections</label>
+                <button type="button" @click="toggleAllSections()"
+                  class="mt-1 text-sm text-blue-600 hover:text-blue-800 text-left">
+                  <span x-text="areAllSectionsOpen ? 'Collapse All' : 'Expand All'"></span>
+                </button>
+              </div>
+            </div>
           </div>
 
-          <div class="flex justify-between gap-4 mb-4 border-b pb-4">
-            <button onclick="saveConfig()" class="flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-center inline-flex items-center justify-center">
-              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+          <!-- Page Format Settings -->
+          <div class="section-group border rounded-lg p-4 mb-4">
+            <div class="flex items-center justify-between cursor-pointer" @click="pageFormatOpen = !pageFormatOpen">
+              <h2 class="section-title mb-0">Page Format</h2>
+              <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': pageFormatOpen }" fill="none"
+                stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>
-              Save Configuration
-            </button>
-            <label class="flex-1 bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded cursor-pointer text-center inline-flex items-center justify-center">
-              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-              </svg>
-              Load Configuration
-              <input type="file" id="configUpload" accept=".json" class="hidden" onchange="loadConfig(event)">
-            </label>
-            <button onclick="resetConfig()" class="flex-1 bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded text-center inline-flex items-center justify-center">
-              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-              Reset to Default
-            </button>
+            </div>
+            <div x-show="pageFormatOpen" x-transition:enter="transition ease-out duration-200"
+              x-transition:enter-start="opacity-0 transform -translate-y-2"
+              x-transition:enter-end="opacity-100 transform translate-y-0"
+              x-transition:leave="transition ease-in duration-150"
+              x-transition:leave-start="opacity-100 transform translate-y-0"
+              x-transition:leave-end="opacity-0 transform -translate-y-2" class="mt-4">
+              <div class="input-grid">
+                <div class="column-headers">
+                  <div class="column-header">Parameter</div>
+                  <div class="column-header">Value</div>
+                  <div class="column-header">Dimensions </div>
+                </div>
+
+                <!-- Page Format -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v14a2 2 0 01-2 2z" />
+                      </svg>
+                      Page Format
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <select x-model="pageFormat" @change="updatePageDimensions()"
+                      class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                      <option value="A4">A4 (210×297mm)</option>
+                      <option value="A5">A5 (148×210mm)</option>
+                      <option value="Letter">US Letter (215.9×279.4mm)</option>
+                      <option value="Legal">US Legal (215.9×355.6mm)</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Select the page format for printing</div>
+                  </div>
+                </div>
+
+                <!-- Page Orientation -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                      Page Orientation
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <select x-model="pageOrientation" @change="updatePageDimensions()"
+                      class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                      <option value="portrait">Portrait</option>
+                      <option value="landscape">Landscape</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Select the page orientation</div>
+                  </div>
+                </div>
+
+                <div class="input-row">
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600 mt-1">
+                      Width: <span x-text="pageWidth"></span>mm × Height: <span x-text="pageHeight"></span>mm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <form @submit.prevent="generateLabels()">
-            <!-- QR Code Configuration -->
-            <div class="section-group">
-              <h2 class="section-title">QR Code Settings</h2>
-              <div class="input-grid input-grid-5">
-                <div class="input-group">
-                  <label for="prefix" class="text-sm font-medium text-gray-700">ASN Prefix</label>
-                  <input type="text" id="prefix" x-model="prefix" required 
-                    class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 prefix-input" 
-                    placeholder="ASN" />
-                </div>
-                <div class="input-group">
-                  <label for="leadingZeros" class="text-sm font-medium text-gray-700">Leading Zeros</label>
-                  <input type="number" id="leadingZeros" x-model="leadingZeros" required min="0" max="10" step="1" 
-                    class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" />
-                </div>
-                <div class="input-group">
-                  <label for="startNumber" class="text-sm font-medium text-gray-700">Start Number</label>
-                  <input type="number" id="startNumber" x-model="startNumber" required min="1" step="1" 
-                    class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" />
-                </div>
-                <div class="flex-grow"></div>
-                <div class="input-group text-left">
-                  <label class="text-sm font-medium text-gray-700">Sections</label>
-                  <button type="button" @click="toggleAllSections()" class="mt-1 text-sm text-blue-600 hover:text-blue-800 text-left">
-                    <span x-text="areAllSectionsOpen ? 'Collapse All' : 'Expand All'"></span>
-                  </button>
-                </div>
-              </div>
+
+          <!-- Page Margins Settings -->
+          <div class="section-group border rounded-lg p-4 mb-4">
+            <div class="flex items-center justify-between cursor-pointer" @click="pageMarginsOpen = !pageMarginsOpen">
+              <h2 class="section-title mb-0">Page Margins</h2>
+              <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': pageMarginsOpen }" fill="none"
+                stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
             </div>
+            <div x-show="pageMarginsOpen" x-transition:enter="transition ease-out duration-200"
+              x-transition:enter-start="opacity-0 transform -translate-y-2"
+              x-transition:enter-end="opacity-100 transform translate-y-0"
+              x-transition:leave="transition ease-in duration-150"
+              x-transition:leave-start="opacity-100 transform translate-y-0"
+              x-transition:leave-end="opacity-0 transform -translate-y-2" class="mt-4">
+              <div class="input-grid">
+                <div class="column-headers">
+                  <div class="column-header">Parameter</div>
+                  <div class="column-header">Target (mm)</div>
+                  <div class="column-header">Actual (mm)</div>
+                </div>
 
-            <!-- Page Format Settings -->
-            <div class="section-group border rounded-lg p-4 mb-4">
-              <div class="flex items-center justify-between cursor-pointer" @click="pageFormatOpen = !pageFormatOpen">
-                <h2 class="section-title mb-0">Page Format</h2>
-                <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': pageFormatOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                </svg>
-              </div>
-              <div x-show="pageFormatOpen" 
-                   x-transition:enter="transition ease-out duration-200" 
-                   x-transition:enter-start="opacity-0 transform -translate-y-2" 
-                   x-transition:enter-end="opacity-100 transform translate-y-0" 
-                   x-transition:leave="transition ease-in duration-150" 
-                   x-transition:leave-start="opacity-100 transform translate-y-0" 
-                   x-transition:leave-end="opacity-0 transform -translate-y-2"
-                   class="mt-4">
-                <div class="input-grid">
-                  <div class="column-headers">
-                    <div class="column-header">Parameter</div>
-                    <div class="column-header">Value</div>
-                    <div class="column-header">Dimensions </div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10h14M5 14h14" />
+                      </svg>
+                      Top Margin
+                    </label>
                   </div>
-
-                  <!-- Page Format -->
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v14a2 2 0 01-2 2z" />
-                        </svg>
-                        Page Format
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <select x-model="pageFormat" @change="updatePageDimensions()"
-                        class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="A4">A4 (210×297mm)</option>
-                        <option value="A5">A5 (148×210mm)</option>
-                        <option value="Letter">US Letter (215.9×279.4mm)</option>
-                        <option value="Legal">US Legal (215.9×355.6mm)</option>
-                      </select>
-                    </div>
-                    <div class="input-group">
-                      <div class="text-sm text-gray-600">Select the page format for printing</div>
-                    </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetPaddingTop"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
                   </div>
-
-                  <!-- Page Orientation -->
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                        </svg>
-                        Page Orientation
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <select x-model="pageOrientation" @change="updatePageDimensions()"
-                        class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="portrait">Portrait</option>
-                        <option value="landscape">Landscape</option>
-                      </select>
-                    </div>
-                    <div class="input-group">
-                      <div class="text-sm text-gray-600">Select the page orientation</div>
-                    </div>
-                  </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <div class="text-sm text-gray-600 mt-1">
-                        Width: <span x-text="pageWidth"></span>mm × Height: <span x-text="pageHeight"></span>mm
-                      </div>
-                    </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualPaddingTop"
+                      class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input"
+                      min="0" step="0.01" @input="calculatePaddingScaling()" />
                   </div>
                 </div>
-              </div>
-            </div>
 
-            <!-- Page Margins Settings -->
-            <div class="section-group border rounded-lg p-4 mb-4">
-              <div class="flex items-center justify-between cursor-pointer" @click="pageMarginsOpen = !pageMarginsOpen">
-                <h2 class="section-title mb-0">Page Margins</h2>
-                <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': pageMarginsOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                </svg>
-              </div>
-              <div x-show="pageMarginsOpen" 
-                   x-transition:enter="transition ease-out duration-200" 
-                   x-transition:enter-start="opacity-0 transform -translate-y-2" 
-                   x-transition:enter-end="opacity-100 transform translate-y-0" 
-                   x-transition:leave="transition ease-in duration-150" 
-                   x-transition:leave-start="opacity-100 transform translate-y-0" 
-                   x-transition:leave-end="opacity-0 transform -translate-y-2"
-                   class="mt-4">
-                <div class="input-grid">
-                  <div class="column-headers">
-                    <div class="column-header">Parameter</div>
-                    <div class="column-header">Target (mm)</div>
-                    <div class="column-header">Actual (mm)</div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M19 13l-7 7-7-7m14-8l-7 7-7-7" />
+                      </svg>
+                      Bottom Margin
+                    </label>
                   </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10h14M5 14h14" />
-                        </svg>
-                        Top Margin
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetPaddingTop" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualPaddingTop" 
-                        class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input" 
-                        min="0" step="0.01" @input="calculatePaddingScaling()" />
-                    </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetPaddingBottom"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
                   </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-8l-7 7-7-7" />
-                        </svg>
-                        Bottom Margin
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetPaddingBottom" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualPaddingBottom" 
-                        class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input" 
-                        min="0" step="0.01" @input="calculatePaddingScaling()" />
-                    </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualPaddingBottom"
+                      class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input"
+                      min="0" step="0.01" @input="calculatePaddingScaling()" />
                   </div>
+                </div>
 
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
-                        </svg>
-                        Left Margin
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetPaddingLeft" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualPaddingLeft" 
-                        class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input" 
-                        min="0" step="0.01" @input="calculatePaddingScaling()" />
-                    </div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+                      </svg>
+                      Left Margin
+                    </label>
                   </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetPaddingLeft"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualPaddingLeft"
+                      class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input"
+                      min="0" step="0.01" @input="calculatePaddingScaling()" />
+                  </div>
+                </div>
 
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
-                        </svg>
-                        Right Margin
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetPaddingRight" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualPaddingRight" 
-                        class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input" 
-                        min="0" step="0.01" @input="calculatePaddingScaling()" />
-                    </div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+                      </svg>
+                      Right Margin
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetPaddingRight"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualPaddingRight"
+                      class="mt-1 block rounded-md border-red-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 number-input"
+                      min="0" step="0.01" @input="calculatePaddingScaling()" />
                   </div>
                 </div>
               </div>
             </div>
+          </div>
 
-            <!-- Label Spacing Settings -->
-            <div class="section-group border rounded-lg p-4 mb-4">
-              <div class="flex items-center justify-between cursor-pointer" @click="labelDimensionsOpen = !labelDimensionsOpen">
-                <h2 class="section-title mb-0">Label Dimensions</h2>
-                <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': labelDimensionsOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                </svg>
-              </div>
-              <div x-show="labelDimensionsOpen" 
-                   x-transition:enter="transition ease-out duration-200" 
-                   x-transition:enter-start="opacity-0 transform -translate-y-2" 
-                   x-transition:enter-end="opacity-100 transform translate-y-0" 
-                   x-transition:leave="transition ease-in duration-150" 
-                   x-transition:leave-start="opacity-100 transform translate-y-0" 
-                   x-transition:leave-end="opacity-0 transform -translate-y-2"
-                   class="mt-4">
-                <div class="input-grid">
-                  <div class="column-headers">
-                    <div class="column-header">Parameter</div>
-                    <div class="column-header">Target (mm)</div>
-                    <div class="column-header">Actual (mm)</div>
+          <!-- Label Spacing Settings -->
+          <div class="section-group border rounded-lg p-4 mb-4">
+            <div class="flex items-center justify-between cursor-pointer"
+              @click="labelDimensionsOpen = !labelDimensionsOpen">
+              <h2 class="section-title mb-0">Label Dimensions</h2>
+              <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': labelDimensionsOpen }"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+            <div x-show="labelDimensionsOpen" x-transition:enter="transition ease-out duration-200"
+              x-transition:enter-start="opacity-0 transform -translate-y-2"
+              x-transition:enter-end="opacity-100 transform translate-y-0"
+              x-transition:leave="transition ease-in duration-150"
+              x-transition:leave-start="opacity-100 transform translate-y-0"
+              x-transition:leave-end="opacity-0 transform -translate-y-2" class="mt-4">
+              <div class="input-grid">
+                <div class="column-headers">
+                  <div class="column-header">Parameter</div>
+                  <div class="column-header">Target (mm)</div>
+                  <div class="column-header">Actual (mm)</div>
+                </div>
+
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 12h2m12 0h2M6 12h12" />
+                      </svg>
+                      Label Width
+                    </label>
                   </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12h2m12 0h2M6 12h12" />
-                        </svg>
-                        Label Width
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetWidth" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualWidth" 
-                        class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" @input="calculateScaling()" />
-                    </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetWidth"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
                   </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
-                        </svg>
-                        Horizontal Gap
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetGapHorizontal" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualGapHorizontal" 
-                        class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" @input="calculateScaling()" />
-                    </div>
-                  </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
-                        </svg>
-                        Label Height
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetHeight" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualHeight" 
-                        class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" @input="calculateScaling()" />
-                    </div>
-                  </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3v18M16 3v18" />
-                        </svg>
-                        Vertical Gap
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="targetGapVertical" 
-                        class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" />
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="actualGapVertical" 
-                        class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.01" @input="calculateScaling()" />
-                    </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualWidth"
+                      class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" @input="calculateScaling()" />
                   </div>
                 </div>
 
-                <div class="mt-4 p-2 bg-gray-100 rounded">
-                  <div class="flex justify-between items-center">
-                    <span class="font-bold text-sm">Calculated Scaling Factor:</span>
-                    <span x-text="'Horizontal: ' + (scalingFactorX || '1.000') + ' / Vertical: ' + (scalingFactorY || '1.000')" class="font-mono text-xs"></span>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
+                      </svg>
+                      Horizontal Gap
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetGapHorizontal"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualGapHorizontal"
+                      class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" @input="calculateScaling()" />
+                  </div>
+                </div>
+
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
+                      </svg>
+                      Label Height
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetHeight"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualHeight"
+                      class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" @input="calculateScaling()" />
+                  </div>
+                </div>
+
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3v18M16 3v18" />
+                      </svg>
+                      Vertical Gap
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="targetGapVertical"
+                      class="mt-1 block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" />
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="actualGapVertical"
+                      class="mt-1 block rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.01" @input="calculateScaling()" />
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-4 p-2 bg-gray-100 rounded">
+                <div class="flex justify-between items-center">
+                  <span class="font-bold text-sm">Calculated Scaling Factor:</span>
+                  <span
+                    x-text="'Horizontal: ' + (scalingFactorX || '1.000') + ' / Vertical: ' + (scalingFactorY || '1.000')"
+                    class="font-mono text-xs"></span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Label Count Settings -->
+          <div class="section-group border rounded-lg p-4 mb-4">
+            <div class="flex items-center justify-between cursor-pointer" @click="labelCountOpen = !labelCountOpen">
+              <h2 class="section-title mb-0">Label Count</h2>
+              <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': labelCountOpen }" fill="none"
+                stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+            <div x-show="labelCountOpen" x-transition:enter="transition ease-out duration-200"
+              x-transition:enter-start="opacity-0 transform -translate-y-2"
+              x-transition:enter-end="opacity-100 transform translate-y-0"
+              x-transition:leave="transition ease-in duration-150"
+              x-transition:leave-start="opacity-100 transform translate-y-0"
+              x-transition:leave-end="opacity-0 transform -translate-y-2" class="mt-4">
+              <div class="input-grid">
+                <div class="column-headers">
+                  <div class="column-header">Parameter</div>
+                  <div class="column-header">Value</div>
+                  <div class="column-header">Calculated Margins</div>
+                </div>
+
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 6h16M4 12h16M4 18h16" />
+                      </svg>
+                      Labels per Row
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="labelsPerRow"
+                      class="mt-1 block w-full h-9 rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="1" step="1" @input="calculateMargins()" />
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-blue-600 mt-1">Right: [<span
+                        x-text="calculatedRightMargin.toFixed(2)"></span>mm]</div>
+                  </div>
+                </div>
+
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7" />
+                      </svg>
+                      Number of Rows
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="maxRows"
+                      class="mt-1 block w-full h-9 rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="1" step="1" @input="calculateMargins()" />
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-blue-600 mt-1">Bottom: [<span
+                        x-text="calculatedBottomMargin.toFixed(2)"></span>mm]</div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
 
-            <!-- Label Count Settings -->
-            <div class="section-group border rounded-lg p-4 mb-4">
-              <div class="flex items-center justify-between cursor-pointer" @click="labelCountOpen = !labelCountOpen">
-                <h2 class="section-title mb-0">Label Count</h2>
-                <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': labelCountOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                </svg>
-              </div>
-              <div x-show="labelCountOpen" 
-                   x-transition:enter="transition ease-out duration-200" 
-                   x-transition:enter-start="opacity-0 transform -translate-y-2" 
-                   x-transition:enter-end="opacity-100 transform translate-y-0" 
-                   x-transition:leave="transition ease-in duration-150" 
-                   x-transition:leave-start="opacity-100 transform translate-y-0" 
-                   x-transition:leave-end="opacity-0 transform -translate-y-2"
-                   class="mt-4">
-                <div class="input-grid">
-                  <div class="column-headers">
-                    <div class="column-header">Parameter</div>
-                    <div class="column-header">Value</div>
-                    <div class="column-header">Calculated Margins</div>
+          <!-- Text Formatting Section -->
+          <div class="section-group border rounded-lg p-4 mb-4">
+            <div class="flex items-center justify-between cursor-pointer"
+              @click="textFormattingOpen = !textFormattingOpen">
+              <h2 class="section-title mb-0">Text Formatting</h2>
+              <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': textFormattingOpen }"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+            <div x-show="textFormattingOpen" x-transition:enter="transition ease-out duration-200"
+              x-transition:enter-start="opacity-0 transform -translate-y-2"
+              x-transition:enter-end="opacity-100 transform translate-y-0"
+              x-transition:leave="transition ease-in duration-150"
+              x-transition:leave-start="opacity-100 transform translate-y-0"
+              x-transition:leave-end="opacity-0 transform -translate-y-2" class="mt-4">
+              <div class="input-grid">
+                <div class="column-headers">
+                  <div class="column-header">Parameter</div>
+                  <div class="column-header">Value</div>
+                  <div class="column-header">Description</div>
+                </div>
+
+                <!-- ASN Prefix -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                      </svg>
+                      ASN Prefix
+                    </label>
                   </div>
-
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        </svg>
-                        Labels per Row
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="labelsPerRow" 
-                        class="mt-1 block w-full h-9 rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="1" step="1" @input="calculateMargins()" />
-                    </div>
-                    <div class="input-group">
-                      <div class="text-sm text-blue-600 mt-1">Right: [<span x-text="calculatedRightMargin.toFixed(2)"></span>mm]</div>
+                  <div class="input-group">
+                    <div class="checkbox-container">
+                      <input type="checkbox" id="displayPrefix" x-model="showPrefix"
+                        class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+                      <label for="displayPrefix" class="text-sm font-medium text-gray-700">Show Prefix</label>
                     </div>
                   </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Include prefix in Label Text (QR-Code not affected)</div>
+                  </div>
+                </div>
 
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7" />
-                        </svg>
-                        Number of Rows
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="maxRows" 
-                        class="mt-1 block w-full h-9 rounded-md border-blue-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="1" step="1" @input="calculateMargins()" />
-                    </div>
-                    <div class="input-group">
-                      <div class="text-sm text-blue-600 mt-1">Bottom: [<span x-text="calculatedBottomMargin.toFixed(2)"></span>mm]</div>
-                    </div>
+                <!-- Font Family -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 6h16M4 12h16m-7 6h7" />
+                      </svg>
+                      Font Family
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <select x-model="fontFamily"
+                      class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                      <option value="Arial">Arial</option>
+                      <option value="Helvetica">Helvetica</option>
+                      <option value="Tahoma">Tahoma</option>
+                      <option value="Verdana">Verdana</option>
+                      <option value="Times New Roman">Times New Roman</option>
+                      <option value="Georgia">Georgia</option>
+                      <option value="Courier New">Courier New</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Select the font for label text</div>
+                  </div>
+                </div>
+
+                <!-- Font Size -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 6h16M4 12h8m-8 6h16" />
+                      </svg>
+                      Font Size
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <select x-model="fontSize"
+                      class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                      <option value="6">6pt</option>
+                      <option value="7">7pt</option>
+                      <option value="8">8pt</option>
+                      <option value="9">9pt</option>
+                      <option value="10">10pt</option>
+                      <option value="11">11pt</option>
+                      <option value="12">12pt</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Select the font size for label text</div>
+                  </div>
+                </div>
+
+                <!-- Font Weight -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 6h16M4 12h16M4 18h16" />
+                      </svg>
+                      Font Weight
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <select x-model="fontWeight"
+                      class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                      <option value="normal">Normal</option>
+                      <option value="bold">Bold</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Select the font weight for label text</div>
+                  </div>
+                </div>
+
+                <!-- QR Code Spacing -->
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="text-sm font-medium text-gray-700 flex items-center">
+                      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                      </svg>
+                      QR Code Spacing
+                    </label>
+                  </div>
+                  <div class="input-group">
+                    <input type="number" x-model="qrCodeSpacing"
+                      class="mt-1 block w-full h-9 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input"
+                      min="0" step="0.1" />
+                  </div>
+                  <div class="input-group">
+                    <div class="text-sm text-gray-600">Space between QR code and text (mm)</div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
 
-            <!-- Text Formatting Section -->
-            <div class="section-group border rounded-lg p-4 mb-4">
-              <div class="flex items-center justify-between cursor-pointer" @click="textFormattingOpen = !textFormattingOpen">
-                <h2 class="section-title mb-0">Text Formatting</h2>
-                <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': textFormattingOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <!-- Print Testing Section -->
+          <div class="section-group border rounded-lg p-4 mb-4">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center">
+                <h2 class="section-title mb-0">Print Testing</h2>
+                <label class="toggle-switch flex items-center whitespace-nowrap ml-4">
+                  <span class="text-sm text-gray-600 mr-2">Testing Mode</span>
+                  <div class="switch">
+                    <input type="checkbox" x-model="printTestingEnabled" @change="resetPrintTesting()" />
+                    <span class="slider"></span>
+                  </div>
+                </label>
+              </div>
+              <div class="cursor-pointer" @click="printTestingOpen = !printTestingOpen">
+                <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': printTestingOpen }"
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                 </svg>
               </div>
-              <div x-show="textFormattingOpen" 
-                   x-transition:enter="transition ease-out duration-200" 
-                   x-transition:enter-start="opacity-0 transform -translate-y-2" 
-                   x-transition:enter-end="opacity-100 transform translate-y-0" 
-                   x-transition:leave="transition ease-in duration-150" 
-                   x-transition:leave-start="opacity-100 transform translate-y-0" 
-                   x-transition:leave-end="opacity-0 transform -translate-y-2"
-                   class="mt-4">
+            </div>
+            <div x-show="printTestingOpen" x-transition:enter="transition ease-out duration-200"
+              x-transition:enter-start="opacity-0 transform -translate-y-2"
+              x-transition:enter-end="opacity-100 transform translate-y-0"
+              x-transition:leave="transition ease-in duration-150"
+              x-transition:leave-start="opacity-100 transform translate-y-0"
+              x-transition:leave-end="opacity-0 transform -translate-y-2" class="mt-4">
+              <div class="print-testing-section" :class="{ 'active': printTestingEnabled }">
                 <div class="input-grid">
                   <div class="column-headers">
-                    <div class="column-header">Parameter</div>
-                    <div class="column-header">Value</div>
+                    <div class="column-header">Test Options</div>
+                    <div class="column-header">Settings</div>
                     <div class="column-header">Description</div>
                   </div>
 
-                  <!-- ASN Prefix -->
+                  <!-- Show Label Borders -->
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M4 5h16a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V6a1 1 0 011-1z" />
                         </svg>
-                        ASN Prefix
+                        Label Outlines
                       </label>
                     </div>
                     <div class="input-group">
                       <div class="checkbox-container">
-                        <input type="checkbox" id="displayPrefix" x-model="showPrefix" 
+                        <input type="checkbox" id="showBorder" x-model="showBorder"
                           class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
-                        <label for="displayPrefix" class="text-sm font-medium text-gray-700">Show Prefix</label>
+                        <label for="showBorder" class="text-sm font-medium text-gray-700">Show Outlines</label>
                       </div>
                     </div>
                     <div class="input-group">
-                      <div class="text-sm text-gray-600">Include prefix in QR code text</div>
+                      <div class="text-sm text-gray-600">Display borders around each label</div>
                     </div>
                   </div>
 
-                  <!-- Font Family -->
+                  <!-- Border Test -->
+                  <div class="input-row">
+                    <div class="input-group">
+                      <label class="text-sm font-medium text-gray-700">QR code label</label>
+                    </div>
+                    <div class="input-group">
+                      <div class="checkbox-container">
+                        <input type="checkbox" id="borderTestMode" x-model="borderTestMode"
+                          class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+                        <label for="borderTestMode" class="text-sm font-medium text-gray-700">Show QR code label</label>
+                      </div>
+                    </div>
+                    <div class="input-group">
+                      <div class="text-sm text-gray-600">Print labels with QR codes for alignment testing</div>
+                    </div>
+                  </div>
+
+                  <!-- Margin View Mode -->
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                         </svg>
-                        Font Family
+                        Margin View
                       </label>
                     </div>
                     <div class="input-group">
-                      <select x-model="fontFamily" 
+                      <select x-model="marginViewMode"
                         class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="Arial">Arial</option>
-                        <option value="Helvetica">Helvetica</option>
-                        <option value="Tahoma">Tahoma</option>
-                        <option value="Verdana">Verdana</option>
-                        <option value="Times New Roman">Times New Roman</option>
-                        <option value="Georgia">Georgia</option>
-                        <option value="Courier New">Courier New</option>
+                        <option value="none">No margins</option>
+                        <option value="page">Page margins</option>
+                        <option value="label">Label dimensions</option>
+                        <option value="both">Both margins</option>
                       </select>
                     </div>
                     <div class="input-group">
-                      <div class="text-sm text-gray-600">Select the font for label text</div>
+                      <div class="text-sm text-gray-600">Select which margins to display in the preview</div>
                     </div>
                   </div>
 
-                  <!-- Font Size -->
+                  <!-- Selected Labels -->
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                         </svg>
-                        Font Size
+                        Selected Labels
                       </label>
                     </div>
                     <div class="input-group">
-                      <select x-model="fontSize" 
-                        class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="6">6pt</option>
-                        <option value="7">7pt</option>
-                        <option value="8">8pt</option>
-                        <option value="9">9pt</option>
-                        <option value="10">10pt</option>
-                        <option value="11">11pt</option>
-                        <option value="12">12pt</option>
-                      </select>
+                      <input type="text" x-model="selectedLabels"
+                        class="mt-1 block w-full h-9 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        placeholder="e.g., 1,4,8-12" />
                     </div>
                     <div class="input-group">
-                      <div class="text-sm text-gray-600">Select the font size for label text</div>
+                      <div class="text-sm text-gray-600">Specify labels to print (comma-separated, ranges with hyphen)
+                      </div>
                     </div>
                   </div>
 
-                  <!-- Font Weight -->
+                  <!-- Toner Save Mode -->
                   <div class="input-row">
                     <div class="input-group">
                       <label class="text-sm font-medium text-gray-700 flex items-center">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
                         </svg>
-                        Font Weight
+                        Toner Save Mode
                       </label>
                     </div>
                     <div class="input-group">
-                      <select x-model="fontWeight" 
-                        class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="normal">Normal</option>
-                        <option value="bold">Bold</option>
-                      </select>
+                      <div class="checkbox-container">
+                        <input type="checkbox" id="tonerSaveMode" x-model="tonerSaveMode"
+                          class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+                        <label for="tonerSaveMode" class="text-sm font-medium text-gray-700">Enable Toner Save</label>
+                      </div>
                     </div>
                     <div class="input-group">
-                      <div class="text-sm text-gray-600">Select the font weight for label text</div>
-                    </div>
-                  </div>
-
-                  <!-- QR Code Spacing -->
-                  <div class="input-row">
-                    <div class="input-group">
-                      <label class="text-sm font-medium text-gray-700 flex items-center">
-                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
-                        </svg>
-                        QR Code Spacing
-                      </label>
-                    </div>
-                    <div class="input-group">
-                      <input type="number" x-model="qrCodeSpacing" 
-                        class="mt-1 block w-full h-9 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 number-input" 
-                        min="0" step="0.1" />
-                    </div>
-                    <div class="input-group">
-                      <div class="text-sm text-gray-600">Space between QR code and text (mm)</div>
+                      <div class="text-sm text-gray-600">Print with reduced toner density for testing</div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-
-            <!-- Print Testing Section -->
-            <div class="section-group border rounded-lg p-4 mb-4">
-              <div class="flex items-center justify-between">
-                <div class="flex items-center">
-                  <h2 class="section-title mb-0">Print Testing</h2>
-                  <label class="toggle-switch flex items-center whitespace-nowrap ml-4">
-                    <span class="text-sm text-gray-600 mr-2">Testing Mode</span>
-                    <div class="switch">
-                      <input type="checkbox" 
-                             x-model="printTestingEnabled"
-                             @change="resetPrintTesting()" />
-                      <span class="slider"></span>
-                    </div>
-                  </label>
-                </div>
-                <div class="cursor-pointer" @click="printTestingOpen = !printTestingOpen">
-                  <svg class="w-6 h-6 transform transition-transform" :class="{ 'rotate-180': printTestingOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                  </svg>
-                </div>
-              </div>
-              <div x-show="printTestingOpen" 
-                   x-transition:enter="transition ease-out duration-200" 
-                   x-transition:enter-start="opacity-0 transform -translate-y-2" 
-                   x-transition:enter-end="opacity-100 transform translate-y-0" 
-                   x-transition:leave="transition ease-in duration-150" 
-                   x-transition:leave-start="opacity-100 transform translate-y-0" 
-                   x-transition:leave-end="opacity-0 transform -translate-y-2"
-                   class="mt-4">
-                <div class="print-testing-section" :class="{ 'active': printTestingEnabled }">
-                  <div class="input-grid">
-                    <div class="column-headers">
-                      <div class="column-header">Test Options</div>
-                      <div class="column-header">Settings</div>
-                      <div class="column-header">Description</div>
-                    </div>
-
-                    <!-- Show Label Borders -->
-                    <div class="input-row">
-                      <div class="input-group">
-                        <label class="text-sm font-medium text-gray-700 flex items-center">
-                          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5h16a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V6a1 1 0 011-1z" />
-                          </svg>
-                          Label Outlines
-                        </label>
-                      </div>
-                      <div class="input-group">
-                        <div class="checkbox-container">
-                          <input type="checkbox" id="showBorder" x-model="showBorder" 
-                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
-                          <label for="showBorder" class="text-sm font-medium text-gray-700">Show Outlines</label>
-                        </div>
-                      </div>
-                      <div class="input-group">
-                        <div class="text-sm text-gray-600">Display borders around each label</div>
-                      </div>
-                    </div>
-
-                    <!-- Border Test -->
-                    <div class="input-row">
-                      <div class="input-group">
-                        <label class="text-sm font-medium text-gray-700">QR code label</label>
-                      </div>
-                      <div class="input-group">
-                        <div class="checkbox-container">
-                          <input type="checkbox" id="borderTestMode" x-model="borderTestMode" 
-                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
-                          <label for="borderTestMode" class="text-sm font-medium text-gray-700">Show QR code label</label>
-                        </div>
-                      </div>
-                      <div class="input-group">
-                        <div class="text-sm text-gray-600">Print labels with QR codes for alignment testing</div>
-                      </div>
-                    </div>
-
-                    <!-- Margin View Mode -->
-                    <div class="input-row">
-                      <div class="input-group">
-                        <label class="text-sm font-medium text-gray-700 flex items-center">
-                          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                          </svg>
-                          Margin View
-                        </label>
-                      </div>
-                      <div class="input-group">
-                        <select x-model="marginViewMode" 
-                          class="mt-1 block w-full h-9 rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                          <option value="none">No margins</option>
-                          <option value="page">Page margins</option>
-                          <option value="label">Label dimensions</option>
-                          <option value="both">Both margins</option>
-                        </select>
-                      </div>
-                      <div class="input-group">
-                        <div class="text-sm text-gray-600">Select which margins to display in the preview</div>
-                      </div>
-                    </div>
-
-                    <!-- Selected Labels -->
-                    <div class="input-row">
-                      <div class="input-group">
-                        <label class="text-sm font-medium text-gray-700 flex items-center">
-                          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                          </svg>
-                          Selected Labels
-                        </label>
-                      </div>
-                      <div class="input-group">
-                        <input type="text" x-model="selectedLabels" 
-                          class="mt-1 block w-full h-9 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-                          placeholder="e.g., 1,4,8-12" />
-                      </div>
-                      <div class="input-group">
-                        <div class="text-sm text-gray-600">Specify labels to print (comma-separated, ranges with hyphen)</div>
-                      </div>
-                    </div>
-
-                    <!-- Toner Save Mode -->
-                    <div class="input-row">
-                      <div class="input-group">
-                        <label class="text-sm font-medium text-gray-700 flex items-center">
-                          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
-                          </svg>
-                          Toner Save Mode
-                        </label>
-                      </div>
-                      <div class="input-group">
-                        <div class="checkbox-container">
-                          <input type="checkbox" id="tonerSaveMode" x-model="tonerSaveMode" 
-                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
-                          <label for="tonerSaveMode" class="text-sm font-medium text-gray-700">Enable Toner Save</label>
-                        </div>
-                      </div>
-                      <div class="input-group">
-                        <div class="text-sm text-gray-600">Print with reduced toner density for testing</div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Action Buttons -->
-            <div class="flex justify-between items-center w-full">
-              <button @click.prevent="generateLabels()" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-[200px] text-center inline-flex items-center justify-center">
-                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                </svg>
-                Update Labels
-              </button>
-              <button @click.prevent="printLabels()" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded w-[200px] text-center inline-flex items-center justify-center">
-                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
-                </svg>
-                Print Labels
-              </button>
           </div>
-      </form>
-        </div>
+
+          <!-- Action Buttons -->
+          <div class="flex justify-between items-center w-full">
+            <button @click.prevent="generateLabels()"
+              class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-[200px] text-center inline-flex items-center justify-center">
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Update Labels
+            </button>
+            <button @click.prevent="printLabels()"
+              class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded w-[200px] text-center inline-flex items-center justify-center">
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+              </svg>
+              Print Labels
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
 
-      <div class="preview-container print-hidden">
-        <div class="page-preview" :class="{
+    <div class="preview-container print-hidden">
+      <div class="page-preview" :class="{
           'margin-view-page': marginViewMode === 'page',
           'margin-view-label': marginViewMode === 'label',
           'margin-view-both': marginViewMode === 'both'
         }">
-          <div class="a4-border"></div>
-          
-          <!-- Page Margins Visualization -->
-          <div class="padding-visualization" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}"></div>
-          
-          <!-- Page Margins Labels -->
-          <div class="padding-label padding-top" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingTop + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          <div class="padding-label padding-bottom" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingBottom + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          <div class="padding-label padding-left" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingLeft + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          <div class="padding-label padding-right" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingRight + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          
-          <!-- Label Dimensions Visualization -->
-          <div class="label-dimensions-visualization" 
-               :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div class="label-dimensions-grid">
-              <template x-for="row in maxRows">
-                <template x-for="col in labelsPerRow">
-                  <div class="label-dimensions-cell"></div>
-                </template>
-              </template>
-            </div>
-            <!-- Label Dimensions Labels -->
-            <div class="label-dimensions-label label-dimensions-top" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="targetPaddingTop + 'mm'" class="text-blue-600"></div>
-            </div>
-            <div class="label-dimensions-label label-dimensions-bottom" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="calculatedBottomMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
-            </div>
-            <div class="label-dimensions-label label-dimensions-left" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="targetPaddingLeft + 'mm'" class="text-blue-600"></div>
-            </div>
-            <div class="label-dimensions-label label-dimensions-right" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="calculatedRightMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
-            </div>
-          </div>
-          
-          <!-- Warning for overlapping labels -->
-          <div x-show="isOverflowingRight || isOverflowingBottom" 
-               class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mt-4" 
-               role="alert">
-            <template x-if="isOverflowingRight">
-          <div>
-                <p class="mb-2">Warning: Labels overlap the right margin by <span x-text="Math.abs(calculatedRightMargin).toFixed(2)"></span>mm</p>
-                <p class="text-sm">Calculation details:</p>
-                <ul class="text-sm list-disc ml-4">
-                  <li>Total label width: <span x-text="marginCalculationDetails.totalLabelWidth"></span>mm</li>
-                  <li>Total gap width: <span x-text="marginCalculationDetails.totalGapWidth"></span>mm</li>
-                  <li>Total width needed: <span x-text="marginCalculationDetails.totalWidth"></span>mm</li>
-                  <li>Available width: <span x-text="marginCalculationDetails.availableWidth"></span>mm</li>
-                </ul>
-              </div>
-            </template>
-            <template x-if="isOverflowingBottom">
-              <p class="mt-2">Warning: Labels overlap the bottom margin by <span x-text="Math.abs(calculatedBottomMargin).toFixed(2)"></span>mm</p>
-            </template>
-          </div>
-    <div class="page" id="label-container"></div>
-        </div>
-      </div>
+        <div class="a4-border"></div>
 
-      <!-- Separate print version -->
-      <div class="print-only">
-        <div class="page-preview" :class="{
+        <!-- Page Margins Visualization -->
+        <div class="padding-visualization"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}"></div>
+
+        <!-- Page Margins Labels -->
+        <div class="padding-label padding-top"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingTop + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+        <div class="padding-label padding-bottom"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingBottom + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+        <div class="padding-label padding-left"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingLeft + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+        <div class="padding-label padding-right"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingRight + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+
+        <!-- Label Dimensions Visualization -->
+        <div class="label-dimensions-visualization"
+          :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div class="label-dimensions-grid">
+            <template x-for="row in maxRows">
+              <template x-for="col in labelsPerRow">
+                <div class="label-dimensions-cell"></div>
+              </template>
+            </template>
+          </div>
+          <!-- Label Dimensions Labels -->
+          <div class="label-dimensions-label label-dimensions-top"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="targetPaddingTop + 'mm'" class="text-blue-600"></div>
+          </div>
+          <div class="label-dimensions-label label-dimensions-bottom"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="calculatedBottomMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
+          </div>
+          <div class="label-dimensions-label label-dimensions-left"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="targetPaddingLeft + 'mm'" class="text-blue-600"></div>
+          </div>
+          <div class="label-dimensions-label label-dimensions-right"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="calculatedRightMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
+          </div>
+        </div>
+
+        <!-- Warning for overlapping labels -->
+        <div x-show="isOverflowingRight || isOverflowingBottom"
+          class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mt-4" role="alert">
+          <template x-if="isOverflowingRight">
+            <div>
+              <p class="mb-2">Warning: Labels overlap the right margin by <span
+                  x-text="Math.abs(calculatedRightMargin).toFixed(2)"></span>mm</p>
+              <p class="text-sm">Calculation details:</p>
+              <ul class="text-sm list-disc ml-4">
+                <li>Total label width: <span x-text="marginCalculationDetails.totalLabelWidth"></span>mm</li>
+                <li>Total gap width: <span x-text="marginCalculationDetails.totalGapWidth"></span>mm</li>
+                <li>Total width needed: <span x-text="marginCalculationDetails.totalWidth"></span>mm</li>
+                <li>Available width: <span x-text="marginCalculationDetails.availableWidth"></span>mm</li>
+              </ul>
+            </div>
+          </template>
+          <template x-if="isOverflowingBottom">
+            <p class="mt-2">Warning: Labels overlap the bottom margin by <span
+                x-text="Math.abs(calculatedBottomMargin).toFixed(2)"></span>mm</p>
+          </template>
+        </div>
+        <div class="page" id="label-container"></div>
+      </div>
+    </div>
+
+    <!-- Separate print version -->
+    <div class="print-only">
+      <div class="page-preview" :class="{
           'margin-view-page': marginViewMode === 'page' && printTestingEnabled,
           'margin-view-label': marginViewMode === 'label' && printTestingEnabled,
           'margin-view-both': marginViewMode === 'both' && printTestingEnabled
         }">
-          <div class="a4-border"></div>
-          
-          <!-- Page Margins Visualization -->
-          <div class="padding-visualization" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}"></div>
-          
-          <!-- Page Margins Labels -->
-          <div class="padding-label padding-top" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingTop + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          <div class="padding-label padding-bottom" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingBottom + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          <div class="padding-label padding-left" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingLeft + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          <div class="padding-label padding-right" 
-               :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div x-text="targetPaddingRight + 'mm'" class="mb-1 text-red-600"></div>
-          </div>
-          
-          <!-- Label Dimensions Visualization -->
-          <div class="label-dimensions-visualization" 
-               :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-            <div class="label-dimensions-grid">
-              <template x-for="row in maxRows">
-                <template x-for="col in labelsPerRow">
-                  <div class="label-dimensions-cell"></div>
-                </template>
-              </template>
-            </div>
-            <!-- Label Dimensions Labels -->
-            <div class="label-dimensions-label label-dimensions-top" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="targetPaddingTop + 'mm'" class="text-blue-600"></div>
-            </div>
-            <div class="label-dimensions-label label-dimensions-bottom" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="calculatedBottomMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
-            </div>
-            <div class="label-dimensions-label label-dimensions-left" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="targetPaddingLeft + 'mm'" class="text-blue-600"></div>
-            </div>
-            <div class="label-dimensions-label label-dimensions-right" 
-                 :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
-              <div x-text="calculatedRightMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
-            </div>
-          </div>
-          
-          <div class="page" id="print-label-container"></div>
+        <div class="a4-border"></div>
+
+        <!-- Page Margins Visualization -->
+        <div class="padding-visualization"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}"></div>
+
+        <!-- Page Margins Labels -->
+        <div class="padding-label padding-top"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingTop + 'mm'" class="mb-1 text-red-600"></div>
         </div>
+        <div class="padding-label padding-bottom"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingBottom + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+        <div class="padding-label padding-left"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingLeft + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+        <div class="padding-label padding-right"
+          :class="{'hidden': !['page', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div x-text="targetPaddingRight + 'mm'" class="mb-1 text-red-600"></div>
+        </div>
+
+        <!-- Label Dimensions Visualization -->
+        <div class="label-dimensions-visualization"
+          :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+          <div class="label-dimensions-grid">
+            <template x-for="row in maxRows">
+              <template x-for="col in labelsPerRow">
+                <div class="label-dimensions-cell"></div>
+              </template>
+            </template>
+          </div>
+          <!-- Label Dimensions Labels -->
+          <div class="label-dimensions-label label-dimensions-top"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="targetPaddingTop + 'mm'" class="text-blue-600"></div>
+          </div>
+          <div class="label-dimensions-label label-dimensions-bottom"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="calculatedBottomMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
+          </div>
+          <div class="label-dimensions-label label-dimensions-left"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="targetPaddingLeft + 'mm'" class="text-blue-600"></div>
+          </div>
+          <div class="label-dimensions-label label-dimensions-right"
+            :class="{'hidden': !['label', 'both'].includes(marginViewMode) || !printTestingEnabled}">
+            <div x-text="calculatedRightMargin.toFixed(2) + 'mm'" class="text-blue-600"></div>
+          </div>
+        </div>
+
+        <div class="page" id="print-label-container"></div>
       </div>
     </div>
+  </div>
 
-    <div id="notification" class="notification" style="display: none;"></div>
+  <div id="notification" class="notification" style="display: none;"></div>
 
-    <!-- Copyright Notice -->
-    <div class="text-center text-sm text-gray-600 mt-8 mb-4 print-hidden">
-      © 2025 Murat Güven. All rights reserved. Licensed under the AGPL v3.0.
-      <a href="https://github.com/muguu/ASN-QR-Code-label-generator" class="text-blue-600 hover:text-blue-800">Contribute via GitHub</a>
-    </div>
+  <!-- Copyright Notice -->
+  <div class="text-center text-sm text-gray-600 mt-8 mb-4 print-hidden">
+    © 2025 Murat Güven. All rights reserved. Licensed under the AGPL v3.0.
+    <a href="https://github.com/muguu/ASN-QR-Code-label-generator" class="text-blue-600 hover:text-blue-800">Contribute
+      via GitHub</a>
+  </div>
 
-    <script>
-      function qrCodeApp() {
-        return {
-          pageFormatOpen: false,
-          pageMarginsOpen: false,
-          labelDimensionsOpen: false,
-          labelCountOpen: false,
-          textFormattingOpen: false,
-          printTestingOpen: false,
-          areAllSectionsOpen: false,
+  <script>
+    function qrCodeApp() {
+      return {
+        pageFormatOpen: false,
+        pageMarginsOpen: false,
+        labelDimensionsOpen: false,
+        labelCountOpen: false,
+        textFormattingOpen: false,
+        printTestingOpen: false,
+        areAllSectionsOpen: false,
 
-          toggleAllSections() {
-            const newState = !this.areAllSectionsOpen;
-            this.pageFormatOpen = newState;
-            this.pageMarginsOpen = newState;
-            this.labelDimensionsOpen = newState;
-            this.labelCountOpen = newState;
-            this.textFormattingOpen = newState;
-            this.printTestingOpen = newState;
-            this.areAllSectionsOpen = newState;
-          },
-          startNumber: 1,
-          prefix: "ASN",
-          leadingZeros: 4,
-          showPrefix: true,
-          showBorder: false,
-          paddingTop: 13.14,
-          paddingRight: 8.5,
-          paddingBottom: 13.7,
-          paddingLeft: 8.4,
-          gapVertical: 0,
-          gapHorizontal: 2.5,
-          labels: [],
-          textSize: '12',
-          textFont: 'Tahoma',
-          textWeight: 'normal',
-          qrCodeSpacing: 0.6,
-          targetWidth: 25.35,
-          targetHeight: 10.0,
-          targetGapHorizontal: 2.5,
-          targetGapVertical: 0,
-          actualWidth: 25.35,
-          actualHeight: 10.0,
-          actualGapHorizontal: 2.5,
-          actualGapVertical: 0,
-          scalingFactorX: null,
-          scalingFactorY: null,
-          targetPaddingTop: 13.14,
-          targetPaddingBottom: 13.7,
-          targetPaddingLeft: 8.4,
-          targetPaddingRight: 8.5,
-          actualPaddingTop: 13.14,
-          actualPaddingBottom: 13.7,
-          actualPaddingLeft: 8.4,
-          actualPaddingRight: 8.5,
-          paddingScalingX: null,
-          paddingScalingY: null,
-          labelsPerRow: 7,
-          maxRows: 27,
-          calculatedRightMargin: 0,
-          calculatedBottomMargin: 0,
-          isOverflowingRight: false,
-          isOverflowingBottom: false,
-          marginCalculationDetails: null,
-          fontFamily: 'Arial',
-          fontSize: 8,
-          fontWeight: 'normal',
-          pageFormat: 'A4',
-          pageOrientation: 'portrait',
-          pageWidth: 210,
-          pageHeight: 297,
-          borderTestMode: false,
-          marginViewMode: "both",
-          selectedLabels: "",
-          tonerSaveMode: "off",
-          printTestingEnabled: false,
+        toggleAllSections() {
+          const newState = !this.areAllSectionsOpen;
+          this.pageFormatOpen = newState;
+          this.pageMarginsOpen = newState;
+          this.labelDimensionsOpen = newState;
+          this.labelCountOpen = newState;
+          this.textFormattingOpen = newState;
+          this.printTestingOpen = newState;
+          this.areAllSectionsOpen = newState;
+        },
+        startNumber: 1,
+        prefix: "ASN",
+        leadingZeros: 4,
+        showPrefix: true,
+        showBorder: false,
+        paddingTop: 13.14,
+        paddingRight: 8.5,
+        paddingBottom: 13.7,
+        paddingLeft: 8.4,
+        gapVertical: 0,
+        gapHorizontal: 2.5,
+        labels: [],
+        textSize: '12',
+        textFont: 'Tahoma',
+        textWeight: 'normal',
+        qrCodeSpacing: 0.6,
+        targetWidth: 25.35,
+        targetHeight: 10.0,
+        targetGapHorizontal: 2.5,
+        targetGapVertical: 0,
+        actualWidth: 25.35,
+        actualHeight: 10.0,
+        actualGapHorizontal: 2.5,
+        actualGapVertical: 0,
+        scalingFactorX: null,
+        scalingFactorY: null,
+        targetPaddingTop: 13.14,
+        targetPaddingBottom: 13.7,
+        targetPaddingLeft: 8.4,
+        targetPaddingRight: 8.5,
+        actualPaddingTop: 13.14,
+        actualPaddingBottom: 13.7,
+        actualPaddingLeft: 8.4,
+        actualPaddingRight: 8.5,
+        paddingScalingX: null,
+        paddingScalingY: null,
+        labelsPerRow: 7,
+        maxRows: 27,
+        calculatedRightMargin: 0,
+        calculatedBottomMargin: 0,
+        isOverflowingRight: false,
+        isOverflowingBottom: false,
+        marginCalculationDetails: null,
+        fontFamily: 'Arial',
+        fontSize: 8,
+        fontWeight: 'normal',
+        pageFormat: 'A4',
+        pageOrientation: 'portrait',
+        pageWidth: 210,
+        pageHeight: 297,
+        borderTestMode: false,
+        marginViewMode: "both",
+        selectedLabels: "",
+        tonerSaveMode: "off",
+        printTestingEnabled: false,
 
-          // Page format definitions
-          pageFormats: {
-            'A4': { width: 210, height: 297 },
-            'A5': { width: 148, height: 210 },
-            'Letter': { width: 215.9, height: 279.4 },
-            'Legal': { width: 215.9, height: 355.6 }
-          },
+        // Page format definitions
+        pageFormats: {
+          'A4': { width: 210, height: 297 },
+          'A5': { width: 148, height: 210 },
+          'Letter': { width: 215.9, height: 279.4 },
+          'Legal': { width: 215.9, height: 355.6 }
+        },
 
-          updatePageDimensions() {
-            const format = this.pageFormats[this.pageFormat];
-            if (this.pageOrientation === 'portrait') {
-              this.pageWidth = format.width;
-              this.pageHeight = format.height;
-            } else {
-              this.pageWidth = format.height;
-              this.pageHeight = format.width;
+        updatePageDimensions() {
+          const format = this.pageFormats[this.pageFormat];
+          if (this.pageOrientation === 'portrait') {
+            this.pageWidth = format.width;
+            this.pageHeight = format.height;
+          } else {
+            this.pageWidth = format.height;
+            this.pageHeight = format.width;
+          }
+          this.calculateMargins();
+          this.renderLabels();
+        },
+
+        calculateMargins() {
+          // Berechne den tatsächlichen rechten Rand basierend auf den Etiketten-Parametern
+          const totalLabelWidth = this.labelsPerRow * parseFloat(this.actualWidth);
+          const totalGapWidth = (this.labelsPerRow - 1) * parseFloat(this.actualGapHorizontal);
+          const totalWidth = totalLabelWidth + totalGapWidth;
+          const availableWidth = this.pageWidth - parseFloat(this.actualPaddingLeft); // Seitenbreite - linker Rand
+          this.calculatedRightMargin = availableWidth - totalWidth;
+          this.isOverflowingRight = this.calculatedRightMargin < 0;
+
+          // Berechne den tatsächlichen unteren Rand basierend auf den Etiketten-Parametern
+          const totalLabelHeight = this.maxRows * parseFloat(this.actualHeight);
+          const totalGapHeight = (this.maxRows - 1) * parseFloat(this.actualGapVertical);
+          const totalHeight = totalLabelHeight + totalGapHeight;
+          const availableHeight = this.pageHeight - parseFloat(this.actualPaddingTop); // Seitenhöhe - oberer Rand
+          this.calculatedBottomMargin = availableHeight - totalHeight;
+          this.isOverflowingBottom = this.calculatedBottomMargin < 0;
+
+          // Füge detaillierte Berechnungsinformationen hinzu
+          this.marginCalculationDetails = {
+            totalLabelWidth: totalLabelWidth.toFixed(2),
+            totalGapWidth: totalGapWidth.toFixed(2),
+            totalWidth: totalWidth.toFixed(2),
+            availableWidth: availableWidth.toFixed(2)
+          };
+
+          // Füge den Aufruf der neuen Methode hinzu
+          this.updateSelectedLabels();
+
+          this.renderLabels();
+        },
+
+        calculateScaling() {
+          if (this.actualWidth && this.targetWidth) {
+            const widthScaling = parseFloat(this.targetWidth) / parseFloat(this.actualWidth);
+            this.scalingFactorX = widthScaling.toFixed(3);
+            // Wende die Skalierung sofort auf die horizontalen Abstände an
+            if (this.actualGapHorizontal && this.targetGapHorizontal) {
+              this.gapHorizontal = parseFloat(this.targetGapHorizontal);
             }
-            this.calculateMargins();
-            this.renderLabels();
-          },
-
-          calculateMargins() {
-            // Berechne den tatsächlichen rechten Rand basierend auf den Etiketten-Parametern
-            const totalLabelWidth = this.labelsPerRow * parseFloat(this.actualWidth);
-            const totalGapWidth = (this.labelsPerRow - 1) * parseFloat(this.actualGapHorizontal);
-            const totalWidth = totalLabelWidth + totalGapWidth;
-            const availableWidth = this.pageWidth - parseFloat(this.actualPaddingLeft); // Seitenbreite - linker Rand
-            this.calculatedRightMargin = availableWidth - totalWidth;
-            this.isOverflowingRight = this.calculatedRightMargin < 0;
-
-            // Berechne den tatsächlichen unteren Rand basierend auf den Etiketten-Parametern
-            const totalLabelHeight = this.maxRows * parseFloat(this.actualHeight);
-            const totalGapHeight = (this.maxRows - 1) * parseFloat(this.actualGapVertical);
-            const totalHeight = totalLabelHeight + totalGapHeight;
-            const availableHeight = this.pageHeight - parseFloat(this.actualPaddingTop); // Seitenhöhe - oberer Rand
-            this.calculatedBottomMargin = availableHeight - totalHeight;
-            this.isOverflowingBottom = this.calculatedBottomMargin < 0;
-
-            // Füge detaillierte Berechnungsinformationen hinzu
-            this.marginCalculationDetails = {
-              totalLabelWidth: totalLabelWidth.toFixed(2),
-              totalGapWidth: totalGapWidth.toFixed(2),
-              totalWidth: totalWidth.toFixed(2),
-              availableWidth: availableWidth.toFixed(2)
-            };
-
-            // Füge den Aufruf der neuen Methode hinzu
-            this.updateSelectedLabels();
-
-            this.renderLabels();
-          },
-
-          calculateScaling() {
-            if (this.actualWidth && this.targetWidth) {
-              const widthScaling = parseFloat(this.targetWidth) / parseFloat(this.actualWidth);
-              this.scalingFactorX = widthScaling.toFixed(3);
-              // Wende die Skalierung sofort auf die horizontalen Abstände an
-              if (this.actualGapHorizontal && this.targetGapHorizontal) {
-                this.gapHorizontal = parseFloat(this.targetGapHorizontal);
-              }
+          }
+          if (this.actualHeight && this.targetHeight) {
+            const heightScaling = parseFloat(this.targetHeight) / parseFloat(this.actualHeight);
+            this.scalingFactorY = heightScaling.toFixed(3);
+            // Wende die Skalierung sofort auf die vertikalen Abstände an
+            if (this.actualGapVertical && this.targetGapVertical) {
+              this.gapVertical = parseFloat(this.targetGapVertical);
             }
-            if (this.actualHeight && this.targetHeight) {
-              const heightScaling = parseFloat(this.targetHeight) / parseFloat(this.actualHeight);
-              this.scalingFactorY = heightScaling.toFixed(3);
-              // Wende die Skalierung sofort auf die vertikalen Abstände an
-              if (this.actualGapVertical && this.targetGapVertical) {
-                this.gapVertical = parseFloat(this.targetGapVertical);
-              }
-            }
-            this.renderLabels();
-          },
+          }
+          this.renderLabels();
+        },
 
-          applyScaling() {
-            if (this.scalingFactorX && this.scalingFactorY) {
-              // Wende Skalierung auf die Abstände an
-              this.gapHorizontal = this.targetGapHorizontal;
-              this.gapVertical = this.targetGapVertical;
-              
-              // Generiere Labels neu
-              this.generateLabels();
-            }
-          },
+        applyScaling() {
+          if (this.scalingFactorX && this.scalingFactorY) {
+            // Wende Skalierung auf die Abstände an
+            this.gapHorizontal = this.targetGapHorizontal;
+            this.gapVertical = this.targetGapVertical;
 
-          calculatePaddingScaling() {
-            if (this.actualPaddingLeft && this.targetPaddingLeft && this.actualPaddingRight && this.targetPaddingRight) {
-              const leftScaling = parseFloat(this.targetPaddingLeft) / parseFloat(this.actualPaddingLeft);
-              const rightScaling = parseFloat(this.targetPaddingRight) / parseFloat(this.actualPaddingRight);
-              const horizontalScaling = (leftScaling + rightScaling) / 2;
-              this.paddingScalingX = horizontalScaling.toFixed(3);
-              // Wende die Skalierung sofort auf die horizontalen Ränder an
-              this.paddingLeft = parseFloat(this.targetPaddingLeft);
-              this.paddingRight = parseFloat(this.targetPaddingRight);
-            }
-            if (this.actualPaddingTop && this.targetPaddingTop && this.actualPaddingBottom && this.targetPaddingBottom) {
-              const topScaling = parseFloat(this.targetPaddingTop) / parseFloat(this.actualPaddingTop);
-              const bottomScaling = parseFloat(this.targetPaddingBottom) / parseFloat(this.actualPaddingBottom);
-              const verticalScaling = (topScaling + bottomScaling) / 2;
-              this.paddingScalingY = verticalScaling.toFixed(3);
-              // Wende die Skalierung sofort auf die vertikalen Ränder an
-              this.paddingTop = parseFloat(this.targetPaddingTop);
-              this.paddingBottom = parseFloat(this.targetPaddingBottom);
-            }
-            this.renderLabels();
-          },
+            // Generiere Labels neu
+            this.generateLabels();
+          }
+        },
 
-          applyPaddingScaling() {
-            if (this.paddingScalingX && this.paddingScalingY) {
-              // Wende Skalierung auf die Seitenränder an
-              this.paddingLeft = this.targetPaddingLeft;
-              this.paddingRight = this.targetPaddingRight;
-              this.paddingTop = this.targetPaddingTop;
-              this.paddingBottom = this.targetPaddingBottom;
-              
-              // Generiere Labels neu
-              this.generateLabels();
-            }
-          },
+        calculatePaddingScaling() {
+          if (this.actualPaddingLeft && this.targetPaddingLeft && this.actualPaddingRight && this.targetPaddingRight) {
+            const leftScaling = parseFloat(this.targetPaddingLeft) / parseFloat(this.actualPaddingLeft);
+            const rightScaling = parseFloat(this.targetPaddingRight) / parseFloat(this.actualPaddingRight);
+            const horizontalScaling = (leftScaling + rightScaling) / 2;
+            this.paddingScalingX = horizontalScaling.toFixed(3);
+            // Wende die Skalierung sofort auf die horizontalen Ränder an
+            this.paddingLeft = parseFloat(this.targetPaddingLeft);
+            this.paddingRight = parseFloat(this.targetPaddingRight);
+          }
+          if (this.actualPaddingTop && this.targetPaddingTop && this.actualPaddingBottom && this.targetPaddingBottom) {
+            const topScaling = parseFloat(this.targetPaddingTop) / parseFloat(this.actualPaddingTop);
+            const bottomScaling = parseFloat(this.targetPaddingBottom) / parseFloat(this.actualPaddingBottom);
+            const verticalScaling = (topScaling + bottomScaling) / 2;
+            this.paddingScalingY = verticalScaling.toFixed(3);
+            // Wende die Skalierung sofort auf die vertikalen Ränder an
+            this.paddingTop = parseFloat(this.targetPaddingTop);
+            this.paddingBottom = parseFloat(this.targetPaddingBottom);
+          }
+          this.renderLabels();
+        },
 
-          generateLabels() {
-            this.labels = [];
-            let totalLabels = this.labelsPerRow * this.maxRows;
-            let startNumberInt = parseInt(this.startNumber, 10);
-            for (let i = 0; i < totalLabels; i++) {
-              let number = startNumberInt + i;
-              let text = this.showPrefix ? 
-                this.prefix + number.toString().padStart(this.leadingZeros, "0") : 
-                number.toString().padStart(this.leadingZeros, "0");
-              let qrCodeUrl = this.getQRCodeUrl(text);
-              this.labels.push({ qrCodeUrl, text });
-            }
-            this.calculateMargins();
-          },
+        applyPaddingScaling() {
+          if (this.paddingScalingX && this.paddingScalingY) {
+            // Wende Skalierung auf die Seitenränder an
+            this.paddingLeft = this.targetPaddingLeft;
+            this.paddingRight = this.targetPaddingRight;
+            this.paddingTop = this.targetPaddingTop;
+            this.paddingBottom = this.targetPaddingBottom;
 
-          renderLabels() {
-            let container = document.getElementById("label-container");
-            let printContainer = document.getElementById("print-label-container");
-            container.innerHTML = "";
-            printContainer.innerHTML = "";
-            
-            // Get selected labels
-            const selectedLabels = this.parseSelectedLabels();
-            
-            // Setze die CSS-Variablen für das Layout
-            const root = document.documentElement;
-            root.style.setProperty('--page-width', `${this.pageWidth}mm`);
-            root.style.setProperty('--page-height', `${this.pageHeight}mm`);
-            root.style.setProperty('--padding-top', `${this.paddingTop}mm`);
-            root.style.setProperty('--padding-right', `${this.paddingRight}mm`);
-            root.style.setProperty('--padding-bottom', `${this.paddingBottom}mm`);
-            root.style.setProperty('--padding-left', `${this.paddingLeft}mm`);
-            root.style.setProperty('--gap-vertical', `${this.gapVertical}mm`);
-            root.style.setProperty('--gap-horizontal', `${this.gapHorizontal}mm`);
-            root.style.setProperty('--text-size', `${this.fontSize}pt`);
-            root.style.setProperty('--text-font', this.fontFamily);
-            root.style.setProperty('--text-weight', this.fontWeight);
-            root.style.setProperty('--qr-code-spacing', `${this.qrCodeSpacing}mm`);
-            root.style.setProperty('--labels-per-row', this.labelsPerRow);
-            root.style.setProperty('--max-rows', this.maxRows);
-            
-            // Setze die Grid-Templates für beide Container
-            const columnsStyle = `repeat(${this.labelsPerRow}, ${this.actualWidth}mm)`;
-            const rowsStyle = `repeat(${this.maxRows}, ${this.actualHeight}mm)`;
-            container.style.gridTemplateColumns = columnsStyle;
-            container.style.gridTemplateRows = rowsStyle;
-            printContainer.style.gridTemplateColumns = columnsStyle;
-            printContainer.style.gridTemplateRows = rowsStyle;
-            
-            this.labels.forEach((label, index) => {
-              // Prüfe, ob das Label angezeigt werden soll
-              const isSelected = !this.printTestingEnabled || selectedLabels.length === 0 || selectedLabels.includes(index + 1);
+            // Generiere Labels neu
+            this.generateLabels();
+          }
+        },
 
-              // Erstelle Label-Divs für Preview und Print
-              let labelDiv = document.createElement("div");
-              let printLabelDiv = document.createElement("div");
+        generateLabels() {
+          this.labels = [];
 
-              // Füge die Label-Klasse nur hinzu, wenn das Label ausgewählt ist oder wir nicht im Testing Mode sind
-              if (isSelected) {
+          const totalLabels = this.labelsPerRow * this.maxRows;
+          const start = parseInt(this.startNumber, 10);
+
+          for (let i = 0; i < totalLabels; i++) {
+            const number = start + i;                                   // 1,2,3…
+            const padded = number.toString().padStart(this.leadingZeros, "0");
+
+            // value that goes into the QR‑code (always with prefix)
+            const qrData = this.prefix + padded;
+            // text that is printed next to the QR‑code
+            const displayText = this.showPrefix ? qrData : padded;
+            // generate the QR‑code image URL from the *full* data
+            const qrCodeUrl = this.getQRCodeUrl(qrData);
+            this.labels.push({ qrCodeUrl, text: displayText });
+          }
+
+          this.calculateMargins();
+        },
+
+        renderLabels() {
+          let container = document.getElementById("label-container");
+          let printContainer = document.getElementById("print-label-container");
+          container.innerHTML = "";
+          printContainer.innerHTML = "";
+
+          // Get selected labels
+          const selectedLabels = this.parseSelectedLabels();
+
+          // Setze die CSS-Variablen für das Layout
+          const root = document.documentElement;
+          root.style.setProperty('--page-width', `${this.pageWidth}mm`);
+          root.style.setProperty('--page-height', `${this.pageHeight}mm`);
+          root.style.setProperty('--padding-top', `${this.paddingTop}mm`);
+          root.style.setProperty('--padding-right', `${this.paddingRight}mm`);
+          root.style.setProperty('--padding-bottom', `${this.paddingBottom}mm`);
+          root.style.setProperty('--padding-left', `${this.paddingLeft}mm`);
+          root.style.setProperty('--gap-vertical', `${this.gapVertical}mm`);
+          root.style.setProperty('--gap-horizontal', `${this.gapHorizontal}mm`);
+          root.style.setProperty('--text-size', `${this.fontSize}pt`);
+          root.style.setProperty('--text-font', this.fontFamily);
+          root.style.setProperty('--text-weight', this.fontWeight);
+          root.style.setProperty('--qr-code-spacing', `${this.qrCodeSpacing}mm`);
+          root.style.setProperty('--labels-per-row', this.labelsPerRow);
+          root.style.setProperty('--max-rows', this.maxRows);
+
+          // Setze die Grid-Templates für beide Container
+          const columnsStyle = `repeat(${this.labelsPerRow}, ${this.actualWidth}mm)`;
+          const rowsStyle = `repeat(${this.maxRows}, ${this.actualHeight}mm)`;
+          container.style.gridTemplateColumns = columnsStyle;
+          container.style.gridTemplateRows = rowsStyle;
+          printContainer.style.gridTemplateColumns = columnsStyle;
+          printContainer.style.gridTemplateRows = rowsStyle;
+
+          this.labels.forEach((label, index) => {
+            // Prüfe, ob das Label angezeigt werden soll
+            const isSelected = !this.printTestingEnabled || selectedLabels.length === 0 || selectedLabels.includes(index + 1);
+
+            // Erstelle Label-Divs für Preview und Print
+            let labelDiv = document.createElement("div");
+            let printLabelDiv = document.createElement("div");
+
+            // Füge die Label-Klasse nur hinzu, wenn das Label ausgewählt ist oder wir nicht im Testing Mode sind
+            if (isSelected) {
               labelDiv.classList.add("label");
-                printLabelDiv.classList.add("label");
+              printLabelDiv.classList.add("label");
 
-                // Setze den Rahmen nur wenn showBorder aktiv ist UND wir im Testing Mode sind
-                if (this.showBorder && this.printTestingEnabled) {
-                  labelDiv.style.border = '0.1mm solid black';
-                  printLabelDiv.style.border = '0.1mm solid black';
-                }
-
-                // Füge den Inhalt hinzu
-                if (!this.printTestingEnabled || this.borderTestMode) {
-                  // Preview version
-              let qrImg = document.createElement("img");
-              qrImg.src = label.qrCodeUrl;
-              qrImg.classList.add("qr-code");
-                  labelDiv.appendChild(qrImg);
-
-              let textDiv = document.createElement("div");
-              textDiv.classList.add("text");
-              textDiv.innerText = label.text;
-              labelDiv.appendChild(textDiv);
-
-                  // Print version
-                  let printQrImg = document.createElement("img");
-                  printQrImg.src = label.qrCodeUrl;
-                  printQrImg.classList.add("qr-code");
-                  printLabelDiv.appendChild(printQrImg);
-
-                  let printTextDiv = document.createElement("div");
-                  printTextDiv.classList.add("text");
-                  printTextDiv.innerText = label.text;
-                  printLabelDiv.appendChild(printTextDiv);
-                }
-              } else {
-                // Für nicht ausgewählte Labels: Füge nur ein leeres Div ohne Klassen oder Styles hinzu
-                labelDiv.style.gridColumn = "span 1";
-                labelDiv.style.gridRow = "span 1";
-                printLabelDiv.style.gridColumn = "span 1";
-                printLabelDiv.style.gridRow = "span 1";
+              // Setze den Rahmen nur wenn showBorder aktiv ist UND wir im Testing Mode sind
+              if (this.showBorder && this.printTestingEnabled) {
+                labelDiv.style.border = '0.1mm solid black';
+                printLabelDiv.style.border = '0.1mm solid black';
               }
-              
-              // Füge die Divs zum Container hinzu
-              container.appendChild(labelDiv);
-              printContainer.appendChild(printLabelDiv);
-            });
-          },
 
-          printLabels() {
-            // Speichere aktuelle Scroll-Position
-            const scrollPos = window.scrollY;
+              // Füge den Inhalt hinzu
+              if (!this.printTestingEnabled || this.borderTestMode) {
+                // Preview version
+                let qrImg = document.createElement("img");
+                qrImg.src = label.qrCodeUrl;
+                qrImg.classList.add("qr-code");
+                labelDiv.appendChild(qrImg);
 
-            // Setze optimale Druckeinstellungen
-            const style = document.createElement('style');
-            style.textContent = `
+                let textDiv = document.createElement("div");
+                textDiv.classList.add("text");
+                textDiv.innerText = label.text;
+                labelDiv.appendChild(textDiv);
+
+                // Print version
+                let printQrImg = document.createElement("img");
+                printQrImg.src = label.qrCodeUrl;
+                printQrImg.classList.add("qr-code");
+                printLabelDiv.appendChild(printQrImg);
+
+                let printTextDiv = document.createElement("div");
+                printTextDiv.classList.add("text");
+                printTextDiv.innerText = label.text;
+                printLabelDiv.appendChild(printTextDiv);
+              }
+            } else {
+              // Für nicht ausgewählte Labels: Füge nur ein leeres Div ohne Klassen oder Styles hinzu
+              labelDiv.style.gridColumn = "span 1";
+              labelDiv.style.gridRow = "span 1";
+              printLabelDiv.style.gridColumn = "span 1";
+              printLabelDiv.style.gridRow = "span 1";
+            }
+
+            // Füge die Divs zum Container hinzu
+            container.appendChild(labelDiv);
+            printContainer.appendChild(printLabelDiv);
+          });
+        },
+
+        printLabels() {
+          // Speichere aktuelle Scroll-Position
+          const scrollPos = window.scrollY;
+
+          // Setze optimale Druckeinstellungen
+          const style = document.createElement('style');
+          style.textContent = `
               @page { size: ${this.pageWidth}mm ${this.pageHeight}mm; margin: 0; }
               @media print {
                 html, body {
@@ -1948,184 +2019,402 @@
                 }
               }
             `;
-            document.head.appendChild(style);
+          document.head.appendChild(style);
 
-            // Warte auf Bilder
-            Promise.all(
-              Array.from(document.images)
-                .filter(img => !img.complete)
-                .map(img => new Promise(resolve => {
-                  img.onload = img.onerror = resolve;
-                }))
-            ).then(() => {
+          // Warte auf Bilder
+          Promise.all(
+            Array.from(document.images)
+              .filter(img => !img.complete)
+              .map(img => new Promise(resolve => {
+                img.onload = img.onerror = resolve;
+              }))
+          ).then(() => {
             window.print();
-              
-              // Cleanup
-              document.head.removeChild(style);
-              window.scrollTo(0, scrollPos);
-            });
-          },
 
-          // Parse selected labels string into array of numbers
-          parseSelectedLabels() {
-            if (!this.selectedLabels) return [];
-            return this.selectedLabels.split(',').flatMap(range => {
-              const [start, end] = range.split('-').map(num => parseInt(num.trim()));
-              if (!end) return [start];
-              return Array.from({length: end - start + 1}, (_, i) => start + i);
-            }).filter(num => !isNaN(num));
-          },
+            // Cleanup
+            document.head.removeChild(style);
+            window.scrollTo(0, scrollPos);
+          });
+        },
 
-          // Modify QR code URL based on toner save mode
-          getQRCodeUrl(text) {
-            let baseUrl = `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(text)}`;
-            switch(this.tonerSaveMode) {
-              case "light":
-                return `${baseUrl}&qzone=1&format=svg&ecc=L`;
-              case "medium":
-                return `${baseUrl}&qzone=2&format=svg&ecc=L`;
-              case "heavy":
-                return `${baseUrl}&qzone=3&format=svg&ecc=L`;
-              default:
-                return `${baseUrl}&size=100x100`;
-            }
-          },
+        // Parse selected labels string into array of numbers
+        parseSelectedLabels() {
+          if (!this.selectedLabels) return [];
+          return this.selectedLabels.split(',').flatMap(range => {
+            const [start, end] = range.split('-').map(num => parseInt(num.trim()));
+            if (!end) return [start];
+            return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+          }).filter(num => !isNaN(num));
+        },
 
-          // Methode zum Zurücksetzen der Print Testing Einstellungen
-          resetPrintTesting() {
-            // Setze die Einstellungen basierend auf dem Testing Mode
-            if (this.printTestingEnabled) {
-              // Aktiviere die Standard-Test-Einstellungen
-              this.marginViewMode = "both";
-              this.selectedLabels = "1,7,183,189"; // Ecklabels für 7x27 Layout
-              this.showBorder = true;
-              this.borderTestMode = false;
-              this.tonerSaveMode = "off";
-            } else {
-              // Deaktiviere alle Test-Einstellungen
-              this.borderTestMode = false;
-              this.marginViewMode = "none";
-              this.selectedLabels = "";
-              this.tonerSaveMode = "off";
-              this.showBorder = false;
-            }
-            // Generiere die Labels komplett neu
-            this.labels = [];
-            this.generateLabels();
-          },
-
-          init() {
-            this.$watch('printTestingEnabled', (value) => {
-              this.resetPrintTesting();
-            });
-            this.generateLabels();
-          },
-
-          // Neue Variable für die Initialisierung
-          isInitialized: false,
-
-          // Neue Methode zur Überprüfung und Aktualisierung der Vorauswahl
-          updateSelectedLabels() {
-            if (this.labelsPerRow && this.maxRows && !this.isInitialized) {
-              // Berechne die Positionen der Ecklabels
-              const firstLabel = 1;                              // Links oben (erstes Label)
-              const topRight = this.labelsPerRow;               // Rechts oben (letztes Label in der ersten Reihe)
-              const bottomLeft = (this.maxRows - 1) * this.labelsPerRow + 1;  // Links unten (erstes Label in der letzten Reihe)
-              const bottomRight = this.maxRows * this.labelsPerRow;           // Rechts unten (letztes Label)
-              
-              // Setze die ausgewählten Labels
-              this.selectedLabels = `${firstLabel},${topRight},${bottomLeft},${bottomRight}`;
-              this.isInitialized = true;
-            }
-          },
-        };
-      }
-
-      let defaultConfig = null;
-
-      // Lade die Standardkonfiguration
-      async function loadDefaultConfig() {
-        try {
-          console.log('Versuche config.json zu laden...');
-          const response = await fetch('./config.json');
-          if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+        // Modify QR code URL based on toner save mode
+        getQRCodeUrl(text) {
+          let baseUrl = `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(text)}`;
+          switch (this.tonerSaveMode) {
+            case "light":
+              return `${baseUrl}&qzone=1&format=svg&ecc=L`;
+            case "medium":
+              return `${baseUrl}&qzone=2&format=svg&ecc=L`;
+            case "heavy":
+              return `${baseUrl}&qzone=3&format=svg&ecc=L`;
+            default:
+              return `${baseUrl}&size=100x100`;
           }
-          console.log('config.json erfolgreich geladen');
-          const config = await response.json();
-          console.log('Geladene Konfiguration:', config);
-          defaultConfig = config;
-          return config;
-        } catch (error) {
-          console.error('Detaillierter Fehler beim Laden der Standardkonfiguration:', error);
-          // Fallback: Verwende hartcodierte Standardwerte
-          const fallbackConfig = {
-            "pageMargins": {
-              "top": {
-                "target": 13.14,
-                "actual": 13.14
-              },
-              "bottom": {
-                "target": 13.7,
-                "actual": 13.7
-              },
-              "left": {
-                "target": 8.4,
-                "actual": 8.4
-              },
-              "right": {
-                "target": 8.5,
-                "actual": 8.5
-              }
-            },
-            "labelDimensions": {
-              "width": {
-                "target": 25.35,
-                "actual": 25.35
-              },
-              "height": {
-                "target": 10.0,
-                "actual": 10.0
-              }
-            },
-            "labelCount": {
-              "labelsPerRow": 7,
-              "numberOfRows": 27
-            },
-            "spacing": {
-              "horizontal": 2.5,
-              "vertical": 0
-            },
-            "qrCode": {
-              "width": 9,
-              "height": 9,
-              "marginLeft": 0.5
-            },
-            "text": {
-              "fontSize": 11,
-              "fontFamily": "Arial",
-              "maxWidth": 14,
-              "paddingLeft": 1
-            }
-          };
-          console.log('Verwende Fallback-Konfiguration:', fallbackConfig);
-          defaultConfig = fallbackConfig;
-          return fallbackConfig;
+        },
+
+        // Methode zum Zurücksetzen der Print Testing Einstellungen
+        resetPrintTesting() {
+          // Setze die Einstellungen basierend auf dem Testing Mode
+          if (this.printTestingEnabled) {
+            // Aktiviere die Standard-Test-Einstellungen
+            this.marginViewMode = "both";
+            this.selectedLabels = "1,7,183,189"; // Ecklabels für 7x27 Layout
+            this.showBorder = true;
+            this.borderTestMode = false;
+            this.tonerSaveMode = "off";
+          } else {
+            // Deaktiviere alle Test-Einstellungen
+            this.borderTestMode = false;
+            this.marginViewMode = "none";
+            this.selectedLabels = "";
+            this.tonerSaveMode = "off";
+            this.showBorder = false;
+          }
+          // Generiere die Labels komplett neu
+          this.labels = [];
+          this.generateLabels();
+        },
+
+        init() {
+          this.$watch('printTestingEnabled', (value) => {
+            this.resetPrintTesting();
+          });
+          this.generateLabels();
+        },
+
+        // Neue Variable für die Initialisierung
+        isInitialized: false,
+
+        // Neue Methode zur Überprüfung und Aktualisierung der Vorauswahl
+        updateSelectedLabels() {
+          if (this.labelsPerRow && this.maxRows && !this.isInitialized) {
+            // Berechne die Positionen der Ecklabels
+            const firstLabel = 1;                              // Links oben (erstes Label)
+            const topRight = this.labelsPerRow;               // Rechts oben (letztes Label in der ersten Reihe)
+            const bottomLeft = (this.maxRows - 1) * this.labelsPerRow + 1;  // Links unten (erstes Label in der letzten Reihe)
+            const bottomRight = this.maxRows * this.labelsPerRow;           // Rechts unten (letztes Label)
+
+            // Setze die ausgewählten Labels
+            this.selectedLabels = `${firstLabel},${topRight},${bottomLeft},${bottomRight}`;
+            this.isInitialized = true;
+          }
+        },
+      };
+    }
+
+    let defaultConfig = null;
+
+    // Lade die Standardkonfiguration
+    async function loadDefaultConfig() {
+      try {
+        console.log('Versuche config.json zu laden...');
+        const response = await fetch('./config.json');
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
         }
+        console.log('config.json erfolgreich geladen');
+        const config = await response.json();
+        console.log('Geladene Konfiguration:', config);
+        defaultConfig = config;
+        return config;
+      } catch (error) {
+        console.error('Detaillierter Fehler beim Laden der Standardkonfiguration:', error);
+        // Fallback: Verwende hartcodierte Standardwerte
+        const fallbackConfig = {
+          "pageMargins": {
+            "top": {
+              "target": 13.14,
+              "actual": 13.14
+            },
+            "bottom": {
+              "target": 13.7,
+              "actual": 13.7
+            },
+            "left": {
+              "target": 8.4,
+              "actual": 8.4
+            },
+            "right": {
+              "target": 8.5,
+              "actual": 8.5
+            }
+          },
+          "labelDimensions": {
+            "width": {
+              "target": 25.35,
+              "actual": 25.35
+            },
+            "height": {
+              "target": 10.0,
+              "actual": 10.0
+            }
+          },
+          "labelCount": {
+            "labelsPerRow": 7,
+            "numberOfRows": 27
+          },
+          "spacing": {
+            "horizontal": 2.5,
+            "vertical": 0
+          },
+          "qrCode": {
+            "width": 9,
+            "height": 9,
+            "marginLeft": 0.5
+          },
+          "text": {
+            "fontSize": 11,
+            "fontFamily": "Arial",
+            "maxWidth": 14,
+            "paddingLeft": 1
+          }
+        };
+        console.log('Verwende Fallback-Konfiguration:', fallbackConfig);
+        defaultConfig = fallbackConfig;
+        return fallbackConfig;
       }
+    }
 
-      // Lade die gespeicherte Konfiguration aus dem localStorage
-      function loadSavedConfig() {
-        const savedConfig = localStorage.getItem('labelConfig');
-        return savedConfig ? JSON.parse(savedConfig) : null;
+    // Lade die gespeicherte Konfiguration aus dem localStorage
+    function loadSavedConfig() {
+      const savedConfig = localStorage.getItem('labelConfig');
+      return savedConfig ? JSON.parse(savedConfig) : null;
+    }
+
+    // Speichere die aktuelle Konfiguration
+    function saveConfig() {
+      try {
+        console.log('Starte Speichervorgang...');
+
+        // Hole Alpine.js Instanz mit Fehlerprüfung
+        const alpineElement = document.querySelector('[x-data="qrCodeApp()"]');
+        if (!alpineElement) {
+          throw new Error('Alpine.js Element nicht gefunden');
+        }
+
+        const alpineApp = Alpine.evaluate(alpineElement, '$data');
+        if (!alpineApp) {
+          throw new Error('Alpine.js Daten nicht verfügbar');
+        }
+
+        console.log('Alpine.js Daten gefunden:', alpineApp);
+
+        const config = {
+          metadata: {
+            version: document.querySelector('.text-gray-600').textContent || "v0.919",
+            description: "Configuration file for the ASN QR Code Label Generator",
+            created: new Date().toISOString(),
+            purpose: "This file contains the settings for the QR code label layout, " +
+              "including page margins, label dimensions, spacing, and text formatting.",
+            usage: "This file can be imported using the 'Load Configuration' button in the application.",
+            generator: "ASN QR Code Label Generator",
+            repository: "https://github.com/muguu/ASN-QR-Code-label-generator"
+          },
+          general: {
+            prefix: alpineApp.prefix,
+            leadingZeros: parseInt(alpineApp.leadingZeros),
+            startNumber: parseInt(alpineApp.startNumber)
+          },
+          pageFormat: {
+            format: alpineApp.pageFormat,
+            orientation: alpineApp.orientation
+          },
+          pageMargins: {
+            viewMode: alpineApp.marginViewMode,
+            top: {
+              target: parseFloat(alpineApp.targetPaddingTop),
+              actual: parseFloat(alpineApp.actualPaddingTop)
+            },
+            bottom: {
+              target: parseFloat(alpineApp.targetPaddingBottom),
+              actual: parseFloat(alpineApp.actualPaddingBottom)
+            },
+            left: {
+              target: parseFloat(alpineApp.targetPaddingLeft),
+              actual: parseFloat(alpineApp.actualPaddingLeft)
+            },
+            right: {
+              target: parseFloat(alpineApp.targetPaddingRight),
+              actual: parseFloat(alpineApp.actualPaddingRight)
+            }
+          },
+          labelDimensions: {
+            width: {
+              target: parseFloat(alpineApp.targetWidth),
+              actual: parseFloat(alpineApp.actualWidth)
+            },
+            height: {
+              target: parseFloat(alpineApp.targetHeight),
+              actual: parseFloat(alpineApp.actualHeight)
+            }
+          },
+          labelCount: {
+            labelsPerRow: parseInt(alpineApp.labelsPerRow),
+            numberOfRows: parseInt(alpineApp.maxRows)
+          },
+          spacing: {
+            horizontal: parseFloat(alpineApp.targetGapHorizontal),
+            vertical: parseFloat(alpineApp.targetGapVertical)
+          },
+          text: {
+            fontSize: parseInt(alpineApp.textSize),
+            fontFamily: alpineApp.textFont,
+            fontWeight: alpineApp.textWeight || 'normal'
+          },
+          display: {
+            showBorder: alpineApp.showBorder,
+            printTestingEnabled: alpineApp.printTestingEnabled,
+            tonerSaveMode: alpineApp.tonerSaveMode
+          },
+          uiState: {
+            pageFormatOpen: alpineApp.pageFormatOpen,
+            pageMarginsOpen: alpineApp.pageMarginsOpen,
+            labelDimensionsOpen: alpineApp.labelDimensionsOpen,
+            labelCountOpen: alpineApp.labelCountOpen,
+            textFormattingOpen: alpineApp.textFormattingOpen,
+            printTestingOpen: alpineApp.printTestingOpen,
+            areAllSectionsOpen: alpineApp.areAllSectionsOpen
+          }
+        };
+
+        console.log('Konfiguration erstellt:', config);
+
+        // Erstelle einen Blob mit der JSON-Konfiguration
+        const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
+        const url = window.URL.createObjectURL(blob);
+
+        // Erstelle einen temporären Download-Link
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'asn-qr-label-config.json';
+        document.body.appendChild(a);
+        a.click();
+
+        // Räume auf
+        window.URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+
+        showNotification('✓ Configuration saved successfully');
+        console.log('Konfiguration erfolgreich gespeichert');
+      } catch (error) {
+        console.error('Detaillierter Fehler beim Speichern:', error);
+        showNotification('Fehler beim Speichern der Konfiguration: ' + error.message, 'error');
       }
+    }
 
-      // Speichere die aktuelle Konfiguration
-      function saveConfig() {
+    // Setze die Konfiguration auf die Standardwerte zurück
+    async function resetConfig() {
+      try {
+        // Lade die Seite neu
+        window.location.reload();
+      } catch (error) {
+        console.error('Fehler beim Zurücksetzen:', error);
+        showNotification('Fehler beim Zurücksetzen der Konfiguration', 'error');
+      }
+    }
+
+    // Benachrichtigungsfunktion
+    function showNotification(message, type = 'success') {
+      const notification = document.getElementById('notification');
+      notification.textContent = message;
+      notification.className = `notification ${type}`;
+      notification.style.display = 'block';
+
+      // Animation starten
+      setTimeout(() => {
+        notification.classList.add('show');
+      }, 10);
+
+      // Nach 3 Sekunden ausblenden
+      setTimeout(() => {
+        notification.classList.remove('show');
+        setTimeout(() => {
+          notification.style.display = 'none';
+        }, 300);
+      }, 3000);
+    }
+
+    // Initialisiere die Konfiguration beim Laden der Seite
+    async function initConfig() {
+      console.log('Starte Initialisierung...');
+
+      // Lade zuerst die Standardkonfiguration
+      const defaultConf = await loadDefaultConfig();
+      console.log('Standardkonfiguration geladen:', defaultConf);
+
+      // Versuche dann, die gespeicherte Konfiguration zu laden
+      const savedConfig = loadSavedConfig();
+      console.log('Gespeicherte Konfiguration:', savedConfig);
+
+      // Verwende die gespeicherte Konfiguration oder die Standardkonfiguration
+      const config = savedConfig || defaultConf;
+      console.log('Verwende Konfiguration:', config);
+
+      if (config) {
         try {
-          console.log('Starte Speichervorgang...');
-          
-          // Hole Alpine.js Instanz mit Fehlerprüfung
+          // Setze alle Eingabefelder auf die geladenen Werte
+          document.getElementById('marginTopTarget').value = config.pageMargins.top.target;
+          document.getElementById('marginTopActual').value = config.pageMargins.top.actual;
+          document.getElementById('marginBottomTarget').value = config.pageMargins.bottom.target;
+          document.getElementById('marginBottomActual').value = config.pageMargins.bottom.actual;
+          document.getElementById('marginLeftTarget').value = config.pageMargins.left.target;
+          document.getElementById('marginLeftActual').value = config.pageMargins.left.actual;
+          document.getElementById('marginRightTarget').value = config.pageMargins.right.target;
+          document.getElementById('marginRightActual').value = config.pageMargins.right.actual;
+
+          document.getElementById('labelWidthTarget').value = config.labelDimensions.width.target;
+          document.getElementById('labelWidthActual').value = config.labelDimensions.width.actual;
+          document.getElementById('labelHeightTarget').value = config.labelDimensions.height.target;
+          document.getElementById('labelHeightActual').value = config.labelDimensions.height.actual;
+
+          document.getElementById('labelsPerRow').value = config.labelCount.labelsPerRow;
+          document.getElementById('numberOfRows').value = config.labelCount.numberOfRows;
+
+          document.getElementById('horizontalSpacing').value = config.spacing.horizontal;
+          document.getElementById('verticalSpacing').value = config.spacing.vertical;
+
+          console.log('Alle Werte wurden gesetzt');
+
+          // Aktualisiere die Anzeige
+          const alpineApp = document.querySelector('[x-data]').__x.$data;
+          alpineApp.generateLabels();
+        } catch (error) {
+          console.error('Fehler beim Setzen der Werte:', error);
+        }
+      } else {
+        console.error('Keine Konfiguration verfügbar');
+      }
+    }
+
+    // Füge Event Listener hinzu
+    document.addEventListener('DOMContentLoaded', initConfig);
+
+    // Lade die hochgeladene Konfigurationsdatei
+    function loadConfig(event) {
+      const file = event.target.files[0];
+      if (!file) {
+        showNotification('Keine Datei ausgewählt', 'error');
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        try {
+          console.log('Lade Konfigurationsdatei...');
+          const config = JSON.parse(e.target.result);
+          console.log('Geladene Konfiguration:', config);
+
+          // Hole Alpine.js Instanz
           const alpineElement = document.querySelector('[x-data="qrCodeApp()"]');
           if (!alpineElement) {
             throw new Error('Alpine.js Element nicht gefunden');
@@ -2135,311 +2424,94 @@
           if (!alpineApp) {
             throw new Error('Alpine.js Daten nicht verfügbar');
           }
-          
-          console.log('Alpine.js Daten gefunden:', alpineApp);
 
-          const config = {
-            metadata: {
-              version: document.querySelector('.text-gray-600').textContent || "v0.919",
-              description: "Configuration file for the ASN QR Code Label Generator",
-              created: new Date().toISOString(),
-              purpose: "This file contains the settings for the QR code label layout, " +
-                      "including page margins, label dimensions, spacing, and text formatting.",
-                      usage: "This file can be imported using the 'Load Configuration' button in the application.",
-                      generator: "ASN QR Code Label Generator",
-                      repository: "https://github.com/muguu/ASN-QR-Code-label-generator"
-            },
-            general: {
-              prefix: alpineApp.prefix,
-              leadingZeros: parseInt(alpineApp.leadingZeros),
-              startNumber: parseInt(alpineApp.startNumber)
-            },
-            pageFormat: {
-              format: alpineApp.pageFormat,
-              orientation: alpineApp.orientation
-            },
-            pageMargins: {
-              viewMode: alpineApp.marginViewMode,
-              top: {
-                target: parseFloat(alpineApp.targetPaddingTop),
-                actual: parseFloat(alpineApp.actualPaddingTop)
-              },
-              bottom: {
-                target: parseFloat(alpineApp.targetPaddingBottom),
-                actual: parseFloat(alpineApp.actualPaddingBottom)
-              },
-              left: {
-                target: parseFloat(alpineApp.targetPaddingLeft),
-                actual: parseFloat(alpineApp.actualPaddingLeft)
-              },
-              right: {
-                target: parseFloat(alpineApp.targetPaddingRight),
-                actual: parseFloat(alpineApp.actualPaddingRight)
-              }
-            },
-            labelDimensions: {
-              width: {
-                target: parseFloat(alpineApp.targetWidth),
-                actual: parseFloat(alpineApp.actualWidth)
-              },
-              height: {
-                target: parseFloat(alpineApp.targetHeight),
-                actual: parseFloat(alpineApp.actualHeight)
-              }
-            },
-            labelCount: {
-              labelsPerRow: parseInt(alpineApp.labelsPerRow),
-              numberOfRows: parseInt(alpineApp.maxRows)
-            },
-            spacing: {
-              horizontal: parseFloat(alpineApp.targetGapHorizontal),
-              vertical: parseFloat(alpineApp.targetGapVertical)
-            },
-            text: {
-              fontSize: parseInt(alpineApp.textSize),
-              fontFamily: alpineApp.textFont,
-              fontWeight: alpineApp.textWeight || 'normal'
-            },
-            display: {
-              showBorder: alpineApp.showBorder,
-              printTestingEnabled: alpineApp.printTestingEnabled,
-              tonerSaveMode: alpineApp.tonerSaveMode
-            },
-            uiState: {
-              pageFormatOpen: alpineApp.pageFormatOpen,
-              pageMarginsOpen: alpineApp.pageMarginsOpen,
-              labelDimensionsOpen: alpineApp.labelDimensionsOpen,
-              labelCountOpen: alpineApp.labelCountOpen,
-              textFormattingOpen: alpineApp.textFormattingOpen,
-              printTestingOpen: alpineApp.printTestingOpen,
-              areAllSectionsOpen: alpineApp.areAllSectionsOpen
-            }
-          };
-
-          console.log('Konfiguration erstellt:', config);
-
-          // Erstelle einen Blob mit der JSON-Konfiguration
-          const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
-          const url = window.URL.createObjectURL(blob);
-          
-          // Erstelle einen temporären Download-Link
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'asn-qr-label-config.json';
-          document.body.appendChild(a);
-          a.click();
-          
-          // Räume auf
-          window.URL.revokeObjectURL(url);
-          document.body.removeChild(a);
-          
-          showNotification('✓ Configuration saved successfully');
-          console.log('Konfiguration erfolgreich gespeichert');
-        } catch (error) {
-          console.error('Detaillierter Fehler beim Speichern:', error);
-          showNotification('Fehler beim Speichern der Konfiguration: ' + error.message, 'error');
-        }
-      }
-
-      // Setze die Konfiguration auf die Standardwerte zurück
-      async function resetConfig() {
-        try {
-          // Lade die Seite neu
-          window.location.reload();
-        } catch (error) {
-          console.error('Fehler beim Zurücksetzen:', error);
-          showNotification('Fehler beim Zurücksetzen der Konfiguration', 'error');
-        }
-      }
-
-      // Benachrichtigungsfunktion
-      function showNotification(message, type = 'success') {
-        const notification = document.getElementById('notification');
-        notification.textContent = message;
-        notification.className = `notification ${type}`;
-        notification.style.display = 'block';
-        
-        // Animation starten
-        setTimeout(() => {
-          notification.classList.add('show');
-        }, 10);
-
-        // Nach 3 Sekunden ausblenden
-        setTimeout(() => {
-          notification.classList.remove('show');
-          setTimeout(() => {
-            notification.style.display = 'none';
-          }, 300);
-        }, 3000);
-      }
-
-      // Initialisiere die Konfiguration beim Laden der Seite
-      async function initConfig() {
-        console.log('Starte Initialisierung...');
-        
-        // Lade zuerst die Standardkonfiguration
-        const defaultConf = await loadDefaultConfig();
-        console.log('Standardkonfiguration geladen:', defaultConf);
-        
-        // Versuche dann, die gespeicherte Konfiguration zu laden
-        const savedConfig = loadSavedConfig();
-        console.log('Gespeicherte Konfiguration:', savedConfig);
-        
-        // Verwende die gespeicherte Konfiguration oder die Standardkonfiguration
-        const config = savedConfig || defaultConf;
-        console.log('Verwende Konfiguration:', config);
-        
-        if (config) {
-          try {
-            // Setze alle Eingabefelder auf die geladenen Werte
-            document.getElementById('marginTopTarget').value = config.pageMargins.top.target;
-            document.getElementById('marginTopActual').value = config.pageMargins.top.actual;
-            document.getElementById('marginBottomTarget').value = config.pageMargins.bottom.target;
-            document.getElementById('marginBottomActual').value = config.pageMargins.bottom.actual;
-            document.getElementById('marginLeftTarget').value = config.pageMargins.left.target;
-            document.getElementById('marginLeftActual').value = config.pageMargins.left.actual;
-            document.getElementById('marginRightTarget').value = config.pageMargins.right.target;
-            document.getElementById('marginRightActual').value = config.pageMargins.right.actual;
-            
-            document.getElementById('labelWidthTarget').value = config.labelDimensions.width.target;
-            document.getElementById('labelWidthActual').value = config.labelDimensions.width.actual;
-            document.getElementById('labelHeightTarget').value = config.labelDimensions.height.target;
-            document.getElementById('labelHeightActual').value = config.labelDimensions.height.actual;
-            
-            document.getElementById('labelsPerRow').value = config.labelCount.labelsPerRow;
-            document.getElementById('numberOfRows').value = config.labelCount.numberOfRows;
-            
-            document.getElementById('horizontalSpacing').value = config.spacing.horizontal;
-            document.getElementById('verticalSpacing').value = config.spacing.vertical;
-            
-            console.log('Alle Werte wurden gesetzt');
-            
-            // Aktualisiere die Anzeige
-            const alpineApp = document.querySelector('[x-data]').__x.$data;
-            alpineApp.generateLabels();
-          } catch (error) {
-            console.error('Fehler beim Setzen der Werte:', error);
+          // Setze die Werte im Alpine.js Datenmodell
+          if (config.general) {
+            alpineApp.prefix = config.general.prefix;
+            alpineApp.leadingZeros = config.general.leadingZeros;
+            alpineApp.startNumber = config.general.startNumber;
           }
-        } else {
-          console.error('Keine Konfiguration verfügbar');
-        }
-      }
 
-      // Füge Event Listener hinzu
-      document.addEventListener('DOMContentLoaded', initConfig);
-
-      // Lade die hochgeladene Konfigurationsdatei
-      function loadConfig(event) {
-        const file = event.target.files[0];
-        if (!file) {
-          showNotification('Keine Datei ausgewählt', 'error');
-          return;
-        }
-
-        const reader = new FileReader();
-        reader.onload = function(e) {
-          try {
-            console.log('Lade Konfigurationsdatei...');
-            const config = JSON.parse(e.target.result);
-            console.log('Geladene Konfiguration:', config);
-
-            // Hole Alpine.js Instanz
-            const alpineElement = document.querySelector('[x-data="qrCodeApp()"]');
-            if (!alpineElement) {
-              throw new Error('Alpine.js Element nicht gefunden');
-            }
-
-            const alpineApp = Alpine.evaluate(alpineElement, '$data');
-            if (!alpineApp) {
-              throw new Error('Alpine.js Daten nicht verfügbar');
-            }
-
-            // Setze die Werte im Alpine.js Datenmodell
-            if (config.general) {
-              alpineApp.prefix = config.general.prefix;
-              alpineApp.leadingZeros = config.general.leadingZeros;
-              alpineApp.startNumber = config.general.startNumber;
-            }
-
-            if (config.pageFormat) {
-              alpineApp.pageFormat = config.pageFormat.format;
-              alpineApp.orientation = config.pageFormat.orientation;
-            }
-
-            if (config.pageMargins) {
-              alpineApp.marginViewMode = config.pageMargins.viewMode;
-              alpineApp.targetPaddingTop = config.pageMargins.top.target;
-              alpineApp.actualPaddingTop = config.pageMargins.top.actual;
-              alpineApp.targetPaddingBottom = config.pageMargins.bottom.target;
-              alpineApp.actualPaddingBottom = config.pageMargins.bottom.actual;
-              alpineApp.targetPaddingLeft = config.pageMargins.left.target;
-              alpineApp.actualPaddingLeft = config.pageMargins.left.actual;
-              alpineApp.targetPaddingRight = config.pageMargins.right.target;
-              alpineApp.actualPaddingRight = config.pageMargins.right.actual;
-            }
-
-            if (config.labelDimensions) {
-              alpineApp.targetWidth = config.labelDimensions.width.target;
-              alpineApp.actualWidth = config.labelDimensions.width.actual;
-              alpineApp.targetHeight = config.labelDimensions.height.target;
-              alpineApp.actualHeight = config.labelDimensions.height.actual;
-            }
-
-            if (config.labelCount) {
-              alpineApp.labelsPerRow = config.labelCount.labelsPerRow;
-              alpineApp.maxRows = config.labelCount.numberOfRows;
-            }
-
-            if (config.spacing) {
-              alpineApp.targetGapHorizontal = config.spacing.horizontal;
-              alpineApp.targetGapVertical = config.spacing.vertical;
-            }
-
-            if (config.text) {
-              alpineApp.textSize = config.text.fontSize;
-              alpineApp.textFont = config.text.fontFamily;
-              alpineApp.textWeight = config.text.fontWeight;
-            }
-
-            if (config.display) {
-              alpineApp.showBorder = config.display.showBorder;
-              alpineApp.printTestingEnabled = config.display.printTestingEnabled;
-              alpineApp.tonerSaveMode = config.display.tonerSaveMode;
-            }
-
-            if (config.uiState) {
-              alpineApp.pageFormatOpen = config.uiState.pageFormatOpen;
-              alpineApp.pageMarginsOpen = config.uiState.pageMarginsOpen;
-              alpineApp.labelDimensionsOpen = config.uiState.labelDimensionsOpen;
-              alpineApp.labelCountOpen = config.uiState.labelCountOpen;
-              alpineApp.textFormattingOpen = config.uiState.textFormattingOpen;
-              alpineApp.printTestingOpen = config.uiState.printTestingOpen;
-              alpineApp.areAllSectionsOpen = config.uiState.areAllSectionsOpen;
-            }
-
-            // Aktualisiere die Labels
-            alpineApp.generateLabels();
-
-            showNotification('✓ Configuration loaded successfully');
-            console.log('Konfiguration erfolgreich geladen und angewendet');
-
-            // Setze das Datei-Input zurück
-            event.target.value = '';
-          } catch (error) {
-            console.error('Detaillierter Fehler beim Laden:', error);
-            showNotification('Fehler beim Laden der Konfiguration: ' + error.message, 'error');
-            event.target.value = '';
+          if (config.pageFormat) {
+            alpineApp.pageFormat = config.pageFormat.format;
+            alpineApp.orientation = config.pageFormat.orientation;
           }
-        };
 
-        reader.onerror = function() {
-          console.error('Fehler beim Lesen der Datei');
-          showNotification('Fehler beim Lesen der Datei', 'error');
+          if (config.pageMargins) {
+            alpineApp.marginViewMode = config.pageMargins.viewMode;
+            alpineApp.targetPaddingTop = config.pageMargins.top.target;
+            alpineApp.actualPaddingTop = config.pageMargins.top.actual;
+            alpineApp.targetPaddingBottom = config.pageMargins.bottom.target;
+            alpineApp.actualPaddingBottom = config.pageMargins.bottom.actual;
+            alpineApp.targetPaddingLeft = config.pageMargins.left.target;
+            alpineApp.actualPaddingLeft = config.pageMargins.left.actual;
+            alpineApp.targetPaddingRight = config.pageMargins.right.target;
+            alpineApp.actualPaddingRight = config.pageMargins.right.actual;
+          }
+
+          if (config.labelDimensions) {
+            alpineApp.targetWidth = config.labelDimensions.width.target;
+            alpineApp.actualWidth = config.labelDimensions.width.actual;
+            alpineApp.targetHeight = config.labelDimensions.height.target;
+            alpineApp.actualHeight = config.labelDimensions.height.actual;
+          }
+
+          if (config.labelCount) {
+            alpineApp.labelsPerRow = config.labelCount.labelsPerRow;
+            alpineApp.maxRows = config.labelCount.numberOfRows;
+          }
+
+          if (config.spacing) {
+            alpineApp.targetGapHorizontal = config.spacing.horizontal;
+            alpineApp.targetGapVertical = config.spacing.vertical;
+          }
+
+          if (config.text) {
+            alpineApp.textSize = config.text.fontSize;
+            alpineApp.textFont = config.text.fontFamily;
+            alpineApp.textWeight = config.text.fontWeight;
+          }
+
+          if (config.display) {
+            alpineApp.showBorder = config.display.showBorder;
+            alpineApp.printTestingEnabled = config.display.printTestingEnabled;
+            alpineApp.tonerSaveMode = config.display.tonerSaveMode;
+          }
+
+          if (config.uiState) {
+            alpineApp.pageFormatOpen = config.uiState.pageFormatOpen;
+            alpineApp.pageMarginsOpen = config.uiState.pageMarginsOpen;
+            alpineApp.labelDimensionsOpen = config.uiState.labelDimensionsOpen;
+            alpineApp.labelCountOpen = config.uiState.labelCountOpen;
+            alpineApp.textFormattingOpen = config.uiState.textFormattingOpen;
+            alpineApp.printTestingOpen = config.uiState.printTestingOpen;
+            alpineApp.areAllSectionsOpen = config.uiState.areAllSectionsOpen;
+          }
+
+          // Aktualisiere die Labels
+          alpineApp.generateLabels();
+
+          showNotification('✓ Configuration loaded successfully');
+          console.log('Konfiguration erfolgreich geladen und angewendet');
+
+          // Setze das Datei-Input zurück
           event.target.value = '';
-        };
+        } catch (error) {
+          console.error('Detaillierter Fehler beim Laden:', error);
+          showNotification('Fehler beim Laden der Konfiguration: ' + error.message, 'error');
+          event.target.value = '';
+        }
+      };
 
-        reader.readAsText(file);
-      }
-    </script>
-  </body>
+      reader.onerror = function () {
+        console.error('Fehler beim Lesen der Datei');
+        showNotification('Fehler beim Lesen der Datei', 'error');
+        event.target.value = '';
+      };
+
+      reader.readAsText(file);
+    }
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
Show Prefix option now only affects the label next to the QR-code Previously, the option would also remove the prefix from the string encoded in the QR-code Previous behavior was not useful, because paperless ngx expects the QR-code to start with the specified prefix Now this option can be used to have the label number be printed larger without the redundant "ASN" at the start.